### PR TITLE
Stronger barcode 💪

### DIFF
--- a/client/src/components/utilities/BarcodeRow.tsx
+++ b/client/src/components/utilities/BarcodeRow.tsx
@@ -19,7 +19,7 @@ const BarcodeRow = (props: BarcodeRowProps) => {
     const drawCodeOnCanvas = (canvas: HTMLCanvasElement) => {
         const c = canvas.getContext('2d')!;
 
-        const chars = ['*', ...code.split(''), '*'];
+        const chars = ['*', ...code.toUpperCase().split('').filter(char => code39Values.hasOwnProperty(char)), '*'];
 
         canvas.height = 100
         canvas.width = chars.length * 16 - 1
@@ -72,10 +72,17 @@ const BarcodeRow = (props: BarcodeRowProps) => {
                         value={code}
                         readOnly={readOnly}
                         onChange={e => {
-                            // Check if the barcode contains any illegal characters
-                            if (![...e.target.value.toUpperCase()].every(x => code39Values[x])) return;
-                            // Autocapitalize letters
-                            updateBarcodeValue && updateBarcodeValue(e.target.value.toUpperCase())
+                            // Filter illegal characters out from the barcode.
+                            // Note: Lowercase letters are capitalised when
+                            // rendering the barcode (so the cursor position
+                            // doesn't reset when typing lowercase letters).
+                            updateBarcodeValue && updateBarcodeValue(
+                                e.target.value
+                                    .split('')
+                                    .filter(char =>
+                                        code39Values.hasOwnProperty(char.toUpperCase()))
+                                    .join('')
+                            )
                         }}
                         onBlur={() => updateBarcodes && updateBarcodes()}
                     />


### PR DESCRIPTION
I made the barcode renderer more resilient by autocapitalising and filtering out illegal characters right before rendering in case the user had typed an illegal lowercase letter before the fix (like me) or some oopsie happens in the future.

I also made the barcode text field more lenient by permitting lowercase letters (they're autocapitalised when rendered, and this prevents the cursor position from being reset while typing letters) as well as filtering out illegal characters when pasting rather than outright rejecting the entire paste

![image](https://user-images.githubusercontent.com/22133785/129823953-a668a95e-65cc-414e-9e11-dd051aa94382.png)
