### PR TITLE
Move `flex: none;` to `.sidebar` to prevent sidebar squishing

### DIFF
--- a/client/src/scss/partials/_sidebar.scss
+++ b/client/src/scss/partials/_sidebar.scss
@@ -7,8 +7,8 @@ $sidebar-padding: 1rem;
 
 $link-padding: 0.5rem;
 // Ensure that icon will always fill collapsed space
-$icon-width: $sidebar-collapsed-width - ($sidebar-padding * 2 + $link-padding * 2);
-
+$icon-width: $sidebar-collapsed-width -
+  ($sidebar-padding * 2 + $link-padding * 2);
 
 %text-truncate {
   overflow: hidden;
@@ -19,6 +19,7 @@ $icon-width: $sidebar-collapsed-width - ($sidebar-padding * 2 + $link-padding * 
 .sidebar {
   width: $sidebar-width;
   transition: width $sidebar-collapse-time ease;
+  flex: none;
 
   // Style for when the sidebar is collapsed
   &.collapsed {
@@ -37,7 +38,6 @@ $icon-width: $sidebar-collapsed-width - ($sidebar-padding * 2 + $link-padding * 
   position: fixed;
   top: 0;
   bottom: 0;
-  flex: none;
   padding: $sidebar-padding;
   display: flex;
   flex-direction: column;
@@ -96,7 +96,8 @@ $icon-width: $sidebar-collapsed-width - ($sidebar-padding * 2 + $link-padding * 
     }
 
     // The <Link> components
-    a, button {
+    a,
+    button {
       transition: background-color 200ms ease;
       padding: $link-padding;
       display: block;


### PR DESCRIPTION
Fixes #41. Not sure how this affects #40.

On select days, the school wrote essays in their event descriptions, and the word wrapping algorithm prefers to stretch out its container as far as possible before wrapping, hence why `.content` stretched into the sidebar's personal space.

The sidebar used to have `flex: none;` but I accidentally moved it to its child in #32. My bad!

![image](https://user-images.githubusercontent.com/22133785/130534466-bf54c67c-63e2-4849-aa77-75e029fd1b62.png)
