### PR TITLE
React 18 + `headlessui` 1.6

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "Gunn-WATT",
       "version": "0.1.0",
       "dependencies": {
-        "@headlessui/react": "^0.0.0-insiders.c4e35f3",
+        "@headlessui/react": "^1.6.2",
         "firebase": "^9.7.0",
         "luxon": "^2.3.2",
         "react": "^18.1.0",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@headlessui/react": {
-      "version": "0.0.0-insiders.c4e35f3",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-0.0.0-insiders.c4e35f3.tgz",
-      "integrity": "sha512-+1rJmGU9CWHIUZf2aXE4l/5izf5MQeDQ+AUhQjHEjBBOzjCDXBhjojgfHbMk+lXcpYzZVj9+YwTiP5dq3H8NJA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.6.2.tgz",
+      "integrity": "sha512-x+kbTjJ+ixgsignqUU9MluoZYBJAlIYMeya4w7dk/Mo13vIdI/mSnzJAVgHhHKzE/hX//+rXylr4jUVThuQq/A==",
       "engines": {
         "node": ">=10"
       },
@@ -17312,9 +17312,9 @@
       }
     },
     "@headlessui/react": {
-      "version": "0.0.0-insiders.c4e35f3",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-0.0.0-insiders.c4e35f3.tgz",
-      "integrity": "sha512-+1rJmGU9CWHIUZf2aXE4l/5izf5MQeDQ+AUhQjHEjBBOzjCDXBhjojgfHbMk+lXcpYzZVj9+YwTiP5dq3H8NJA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.6.2.tgz",
+      "integrity": "sha512-x+kbTjJ+ixgsignqUU9MluoZYBJAlIYMeya4w7dk/Mo13vIdI/mSnzJAVgHhHKzE/hX//+rXylr4jUVThuQq/A==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,7 +17,7 @@
         "react-feather": "^2.0.9",
         "react-hotkeys-hook": "^3.4.4",
         "react-page-visibility": "^7.0.0",
-        "react-responsive": "^9.0.0-beta.6",
+        "react-responsive": "^9.0.0-beta.8",
         "react-router-dom": "^6.3.0",
         "react-scripts": "^5.0.1",
         "reactfire": "^4.2.1",
@@ -12568,9 +12568,9 @@
       }
     },
     "node_modules/react-responsive": {
-      "version": "9.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.0-beta.6.tgz",
-      "integrity": "sha512-Flk6UrnpBBByreva6ja/TsbXiXq4BXOlDEKL6Ur+nshUs3CcN5W0BpGe6ClFWrKcORkMZAAYy7A4N4xlMmpgVw==",
+      "version": "9.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.0-beta.8.tgz",
+      "integrity": "sha512-3DH8YMbYCaZZ6GnsabO7/fWUFDxY5/UMdYQn4kYRBvammJvbvTTfDODo7sb4XsnOoglu0U7S6pVupH5VN+oAoQ==",
       "dependencies": {
         "hyphenate-style-name": "^1.0.0",
         "matchmediaquery": "^0.3.0",
@@ -24488,9 +24488,9 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-responsive": {
-      "version": "9.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.0-beta.6.tgz",
-      "integrity": "sha512-Flk6UrnpBBByreva6ja/TsbXiXq4BXOlDEKL6Ur+nshUs3CcN5W0BpGe6ClFWrKcORkMZAAYy7A4N4xlMmpgVw==",
+      "version": "9.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.0-beta.8.tgz",
+      "integrity": "sha512-3DH8YMbYCaZZ6GnsabO7/fWUFDxY5/UMdYQn4kYRBvammJvbvTTfDODo7sb4XsnOoglu0U7S6pVupH5VN+oAoQ==",
       "requires": {
         "hyphenate-style-name": "^1.0.0",
         "matchmediaquery": "^0.3.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "Gunn-WATT",
       "version": "0.1.0",
       "dependencies": {
-        "@headlessui/react": "^1.5.0",
+        "@headlessui/react": "^0.0.0-insiders.c4e35f3",
         "firebase": "^9.7.0",
         "luxon": "^2.3.2",
         "react": "^18.1.0",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@headlessui/react": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.5.0.tgz",
-      "integrity": "sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==",
+      "version": "0.0.0-insiders.c4e35f3",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-0.0.0-insiders.c4e35f3.tgz",
+      "integrity": "sha512-+1rJmGU9CWHIUZf2aXE4l/5izf5MQeDQ+AUhQjHEjBBOzjCDXBhjojgfHbMk+lXcpYzZVj9+YwTiP5dq3H8NJA==",
       "engines": {
         "node": ">=10"
       },
@@ -17312,9 +17312,9 @@
       }
     },
     "@headlessui/react": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.5.0.tgz",
-      "integrity": "sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==",
+      "version": "0.0.0-insiders.c4e35f3",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-0.0.0-insiders.c4e35f3.tgz",
+      "integrity": "sha512-+1rJmGU9CWHIUZf2aXE4l/5izf5MQeDQ+AUhQjHEjBBOzjCDXBhjojgfHbMk+lXcpYzZVj9+YwTiP5dq3H8NJA==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@headlessui/react": "^1.5.0",
+    "@headlessui/react": "^0.0.0-insiders.c4e35f3",
     "firebase": "^9.7.0",
     "luxon": "^2.3.2",
     "react": "^18.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
     "react-feather": "^2.0.9",
     "react-hotkeys-hook": "^3.4.4",
     "react-page-visibility": "^7.0.0",
-    "react-responsive": "^9.0.0-beta.6",
+    "react-responsive": "^9.0.0-beta.8",
     "react-router-dom": "^6.3.0",
     "react-scripts": "^5.0.1",
     "reactfire": "^4.2.1",

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@headlessui/react": "^0.0.0-insiders.c4e35f3",
+    "@headlessui/react": "^1.6.2",
     "firebase": "^9.7.0",
     "luxon": "^2.3.2",
     "react": "^18.1.0",

--- a/client/src/components/classes/AssignmentModal.tsx
+++ b/client/src/components/classes/AssignmentModal.tsx
@@ -49,62 +49,60 @@ export default function AssignmentModal(props: AssignmentModalProps) {
 
 
     return (
-        <CenteredModal isOpen={open} setIsOpen={setOpen}>
-            <div className="item-modal relative flex flex-col gap-4 bg-sidebar dark:bg-sidebar-dark rounded-md max-w-lg max-h-[90%] p-6 mx-2">
-                <section>
-                    <AssignmentTags item={item} period />
-                    <span className="flex items-center gap-2">
-                        {item.timestamp && (
-                            <CompletedIcon
-                                size={24}
-                                className="cursor-pointer flex-none"
-                                onClick={() => toggleCompleted()}
-                            />
-                        )}
-                        {isCustomAssignment ? (
-                            <Dialog.Title className="text-lg font-semibold">{item.name}</Dialog.Title>
-                        ) : (
-                            <a href={item.link} className="text-inherit dark:text-inherit" target="_blank" rel="noopener noreferrer">
-                                <Dialog.Title className="text-lg font-semibold">{item.name}</Dialog.Title>
-                            </a>
-                        )}
-                    </span>
-                </section>
-
-                {item.description && (
-                    <section className="overflow-scroll scroll-smooth scrollbar-none whitespace-pre-wrap">
-                        <Dialog.Description>{item.description.trim()}</Dialog.Description>
-                    </section>
-                )}
-
-                {item.timestamp && (
-                    <section className="flex gap-3 items-center">
-                        <PriorityPicker priority={item.priority} setPriority={setPriority} />
-
-                        <AssignmentTimestamp>
-                            {item.timestamp.toLocaleString(DateTime.TIME_SIMPLE)} on {item.timestamp.toLocaleString(DATE_MED_NO_YEAR)}
-                        </AssignmentTimestamp>
-
-                        <Edit
-                            className="cursor-pointer text-theme dark:text-theme-dark ml-auto"
-                            onClick={() => setEditing(true)}
+        <CenteredModal className="item-modal relative flex flex-col gap-4 bg-sidebar dark:bg-sidebar-dark rounded-md max-w-lg max-h-[90%] p-6 mx-2" isOpen={open} setIsOpen={setOpen}>
+            <section>
+                <AssignmentTags item={item} period />
+                <span className="flex items-center gap-2">
+                    {item.timestamp && (
+                        <CompletedIcon
+                            size={24}
+                            className="cursor-pointer flex-none"
+                            onClick={() => toggleCompleted()}
                         />
-                        {isCustomAssignment && (
-                            <Trash2
-                                className="cursor-pointer text-theme dark:text-theme-dark"
-                                onClick={deleteCustom}
-                            />
-                        )}
-                        {modified && (
-                            <SkipBack
-                                className="cursor-pointer text-theme dark:text-theme-dark"
-                                onClick={reset}
-                            />
-                        )}
-                        <CreateAssignmentModal open={editing} setOpen={setEditing} item={item} />
-                    </section>
-                )}
-            </div>
+                    )}
+                    {isCustomAssignment ? (
+                        <Dialog.Title className="text-lg font-semibold">{item.name}</Dialog.Title>
+                    ) : (
+                        <a href={item.link} className="text-inherit dark:text-inherit" target="_blank" rel="noopener noreferrer">
+                            <Dialog.Title className="text-lg font-semibold">{item.name}</Dialog.Title>
+                        </a>
+                    )}
+                </span>
+            </section>
+
+            {item.description && (
+                <section className="overflow-scroll scroll-smooth scrollbar-none whitespace-pre-wrap">
+                    <Dialog.Description>{item.description.trim()}</Dialog.Description>
+                </section>
+            )}
+
+            {item.timestamp && (
+                <section className="flex gap-3 items-center">
+                    <PriorityPicker priority={item.priority} setPriority={setPriority} />
+
+                    <AssignmentTimestamp>
+                        {item.timestamp.toLocaleString(DateTime.TIME_SIMPLE)} on {item.timestamp.toLocaleString(DATE_MED_NO_YEAR)}
+                    </AssignmentTimestamp>
+
+                    <Edit
+                        className="cursor-pointer text-theme dark:text-theme-dark ml-auto"
+                        onClick={() => setEditing(true)}
+                    />
+                    {isCustomAssignment && (
+                        <Trash2
+                            className="cursor-pointer text-theme dark:text-theme-dark"
+                            onClick={deleteCustom}
+                        />
+                    )}
+                    {modified && (
+                        <SkipBack
+                            className="cursor-pointer text-theme dark:text-theme-dark"
+                            onClick={reset}
+                        />
+                    )}
+                    <CreateAssignmentModal open={editing} setOpen={setEditing} item={item} />
+                </section>
+            )}
         </CenteredModal>
     )
 }

--- a/client/src/components/classes/Assignments.tsx
+++ b/client/src/components/classes/Assignments.tsx
@@ -60,9 +60,9 @@ export function AssignmentTags({item, period}: {item: AssignmentBlurb, period?: 
 // the individual assignment
 // TODO: instead of taking the assignment as `props.assignment`, would it be neater to take it spread out?
 // ie. `props.name`, `props.link`, `props.timestamp`, with assignment passed in as `{...assignment}`
-type AssignmentProps = { assignment: AssignmentBlurb } & ActiveItemState;
+type AssignmentProps = { assignment: AssignmentBlurb, zIndex?: number } & ActiveItemState;
 function Assignment(props: AssignmentProps) {
-    const { assignment, activeItem, setActiveItem } = props;
+    const { assignment, activeItem, setActiveItem, zIndex } = props;
     const [modal, setModal] = useState(false);
 
     const userData = useContext(UserDataContext);
@@ -86,10 +86,11 @@ function Assignment(props: AssignmentProps) {
 
     return (
         <div
-            className={"upcoming-assignment flex bg-sidebar dark:bg-sidebar-dark rounded transition-transform duration-200" + (!activeItem || activeItem.id !== assignment.id ? '' : " scale-[1.03]")}
+            className={"relative flex bg-sidebar dark:bg-sidebar-dark rounded transition-transform duration-200" + (!activeItem || activeItem.id !== assignment.id ? '' : " scale-[1.03]")}
             id={`assignment-${assignment.id}`}
             onMouseEnter={() => setActiveItem(assignment)}
             onMouseLeave={() => setActiveItem(null)}
+            style={{zIndex}}
         >
             <div className="flex-grow py-4 px-5 cursor-pointer" onClick={() => setModal(!modal)}>
                 <AssignmentTags item={assignment} period />
@@ -156,6 +157,8 @@ export default function Assignments(props: AssignmentsProps & ActiveItemState) {
     const { upcoming, overdue, ...activeDayState } = props;
     const currTime = useContext(CurrentTimeContext);
 
+    let count = 0;
+
     // We map days (like "11-29-2021") to all the assignments that are due on that day
     // that way we can have all the headers and stuff
     const daysMap = new Map<string, AssignmentBlurb[]>();
@@ -166,6 +169,7 @@ export default function Assignments(props: AssignmentsProps & ActiveItemState) {
         } else {
             daysMap.set(day, [assignment]);
         }
+        count++;
     }
 
     const days = [];
@@ -177,18 +181,19 @@ export default function Assignments(props: AssignmentsProps & ActiveItemState) {
     }
 
     return (
-        <div className="upcoming-assignments">
+        <div className="flex flex-col gap-4">
             {days.map(({day, upcoming: currUpcoming}) => (
-                <section key={day.toISO()}>
-                    <div className="upcoming-day-header">
+                <section className="flex flex-col gap-2.5" key={day.toISO()}>
+                    <h3 className="secondary">
                         {day.toLocaleString(DATE_FULL_NO_YEAR)} • In {pluralize(Math.ceil(day.diff(currTime, 'days').days), 'day')}
-                    </div>
+                    </h3>
 
                     {currUpcoming.map((assignment) => (
                         <Assignment
                             key={assignment.id}
                             assignment={assignment}
                             {...activeDayState}
+                            zIndex={count--}
                         />
                     ))}
                 </section>

--- a/client/src/components/classes/ClassFilter.tsx
+++ b/client/src/components/classes/ClassFilter.tsx
@@ -36,7 +36,7 @@ export default function ClassFilter(props: ClassFilterProps) {
 
     return (
         <div>
-            <div className="relative">
+            <div className="relative z-[9999]">
                 <input
                     type="text"
                     placeholder="Search"

--- a/client/src/components/classes/CreateAssignmentModal.tsx
+++ b/client/src/components/classes/CreateAssignmentModal.tsx
@@ -170,14 +170,14 @@ export default function CreateAssignmentModal(props: CreateAssignmentModalProps 
                     <PriorityPicker priority={priority} setPriority={setPriority} align='right' />
 
                     <Popover>
-                        <Popover.Button className="py-0.5 px-1.5 rounded-sm text-[0.8rem] bg-theme dark:bg-theme-dark text-white cursor-pointer" onClick={() => setOpen(!open)}>
+                        <Popover.Button className="py-0.5 px-1.5 rounded-sm text-[0.8rem] bg-theme dark:bg-theme-dark text-white cursor-pointer">
                             {timestamp.toLocaleString(DateTime.TIME_SIMPLE)} on {timestamp.toLocaleString(DATE_MED_NO_YEAR)}
                         </Popover.Button>
                         <Transition
                             as={Fragment}
                             enter="ease-out duration-200 absolute inset-0 m-auto"
                             enterFrom="opacity-0 scale-95"
-                            enterTo="opacity-100 scale-100"
+                            enterTo="opacity-100 scale-100 transform-none" // TODO: does this hacky "transform-none" have implications?
                             leave="ease-in duration-150 absolute inset-0 m-auto"
                             leaveFrom="opacity-100 scale-100"
                             leaveTo="opacity-0 scale-95"

--- a/client/src/components/classes/CreateAssignmentModal.tsx
+++ b/client/src/components/classes/CreateAssignmentModal.tsx
@@ -9,7 +9,7 @@ import CenteredModal from '../layout/CenteredModal';
 import AnimatedPopover from '../layout/AnimatedPopover';
 import OutlineButton, {SuccessOutlineButton} from '../layout/OutlineButton';
 import PriorityPicker from './PriorityPicker';
-import { CalendarPopover } from '../schedule/DateSelector';
+import { Calendar } from '../schedule/DateSelector';
 import { AssignmentTag } from './Assignments';
 import {PopoverPlus, TagPicker, TagPickerLabels} from './ClassFilter';
 
@@ -173,13 +173,14 @@ export default function CreateAssignmentModal(props: CreateAssignmentModalProps 
                         <Popover.Button className="py-0.5 px-1.5 rounded-sm text-[0.8rem] bg-theme dark:bg-theme-dark text-white cursor-pointer" onClick={() => setOpen(!open)}>
                             {timestamp.toLocaleString(DateTime.TIME_SIMPLE)} on {timestamp.toLocaleString(DATE_MED_NO_YEAR)}
                         </Popover.Button>
-                        <CalendarPopover
-                            className="inset-0 m-auto"
-                            currTime={timestamp}
-                            setTime={setTimestamp}
-                            time
-                            start={currTime.startOf('day')}
-                        />
+                        <AnimatedPopover className="inset-0 m-auto">
+                            <Calendar
+                                currTime={timestamp}
+                                setTime={setTimestamp}
+                                time
+                                start={currTime.startOf('day')}
+                            />
+                        </AnimatedPopover>
                     </Popover>
                 </div>
             </section>

--- a/client/src/components/classes/CreateAssignmentModal.tsx
+++ b/client/src/components/classes/CreateAssignmentModal.tsx
@@ -173,14 +173,25 @@ export default function CreateAssignmentModal(props: CreateAssignmentModalProps 
                         <Popover.Button className="py-0.5 px-1.5 rounded-sm text-[0.8rem] bg-theme dark:bg-theme-dark text-white cursor-pointer" onClick={() => setOpen(!open)}>
                             {timestamp.toLocaleString(DateTime.TIME_SIMPLE)} on {timestamp.toLocaleString(DATE_MED_NO_YEAR)}
                         </Popover.Button>
-                        <AnimatedPopover className="inset-0 m-auto">
-                            <Calendar
-                                currTime={timestamp}
-                                setTime={setTimestamp}
-                                time
-                                start={currTime.startOf('day')}
-                            />
-                        </AnimatedPopover>
+                        <Transition
+                            as={Fragment}
+                            enter="ease-out duration-200 absolute inset-0 m-auto"
+                            enterFrom="opacity-0 scale-95"
+                            enterTo="opacity-100 scale-100"
+                            leave="ease-in duration-150 absolute inset-0 m-auto"
+                            leaveFrom="opacity-100 scale-100"
+                            leaveTo="opacity-0 scale-95"
+                        >
+                            <Popover.Panel>
+                                <Calendar
+                                    className="inset-0 m-auto"
+                                    currTime={timestamp}
+                                    setTime={setTimestamp}
+                                    time
+                                    start={currTime.startOf('day')}
+                                />
+                            </Popover.Panel>
+                        </Transition>
                     </Popover>
                 </div>
             </section>

--- a/client/src/components/classes/CreateAssignmentModal.tsx
+++ b/client/src/components/classes/CreateAssignmentModal.tsx
@@ -9,7 +9,7 @@ import CenteredModal from '../layout/CenteredModal';
 import AnimatedPopover from '../layout/AnimatedPopover';
 import OutlineButton, {SuccessOutlineButton} from '../layout/OutlineButton';
 import PriorityPicker from './PriorityPicker';
-import { Calendar } from '../schedule/DateSelector';
+import { CalendarPopover } from '../schedule/DateSelector';
 import { AssignmentTag } from './Assignments';
 import {PopoverPlus, TagPicker, TagPickerLabels} from './ClassFilter';
 
@@ -126,90 +126,76 @@ export default function CreateAssignmentModal(props: CreateAssignmentModalProps 
     }
 
     return (
-        <CenteredModal isOpen={open} setIsOpen={setOpen}>
-            <div className="create-modal relative flex flex-col gap-4 bg-sidebar dark:bg-sidebar-dark rounded-md w-[32rem] max-w-full max-h-[90%] p-6 mx-2">
-                <section>
-                    <div className="assignment-tags" style={{ marginBottom: 5 }}>
-                        {labels.map(label => (
-                            <AssignmentTag key={label} label={parseLabelName(label, userData)} color={parseLabelColor(label, userData)} />
-                        ))}
+        <CenteredModal className="create-modal relative flex flex-col gap-4 bg-sidebar dark:bg-sidebar-dark rounded-md w-[32rem] max-w-full max-h-[90%] p-6 mx-2" isOpen={open} setIsOpen={setOpen}>
+            <section>
+                <div className="assignment-tags" style={{ marginBottom: 5 }}>
+                    {labels.map(label => (
+                        <AssignmentTag key={label} label={parseLabelName(label, userData)} color={parseLabelColor(label, userData)} />
+                    ))}
 
-                        <Popover className="relative cursor-pointer ml-auto">
-                            <PopoverPlus />
-                            <TagPicker>
-                                {(search) => (
-                                    <TagPickerLabels labels={labels} setLabels={setLabels} search={search} />
-                                )}
-                            </TagPicker>
-                        </Popover>
-                    </div>
+                    <Popover className="relative cursor-pointer ml-auto">
+                        <PopoverPlus />
+                        <TagPicker>
+                            {(search) => (
+                                <TagPickerLabels labels={labels} setLabels={setLabels} search={search} />
+                            )}
+                        </TagPicker>
+                    </Popover>
+                </div>
 
-                    {/* Name */}
-                    <input
-                        required
-                        type="text"
-                        placeholder="Assignment Name"
-                        //autoFocus
-                        className="create-name w-full rounded-sm invalid:outline-1 invalid:outline-dashed invalid:outline-theme dark:invalid:outline-theme-dark"
-                        value={name}
-                        onChange={e => setName(e.target.value)}
-                    />
+                {/* Name */}
+                <input
+                    required
+                    type="text"
+                    placeholder="Assignment Name"
+                    //autoFocus
+                    className="create-name w-full rounded-sm invalid:outline-1 invalid:outline-dashed invalid:outline-theme dark:invalid:outline-theme-dark"
+                    value={name}
+                    onChange={e => setName(e.target.value)}
+                />
 
-                    {/* Period */}
-                    <PeriodPicker period={period} setPeriod={setPeriod} />
-                </section>
+                {/* Period */}
+                <PeriodPicker period={period} setPeriod={setPeriod} />
+            </section>
 
-                <section>
-                    <textarea
-                        className="create-desc rounded p-3 w-full outline-none resize-none bg-background dark:bg-background-dark placeholder:text-secondary dark:placeholder:text-secondary-dark placeholder:font-light"
-                        placeholder="Assignment Description [Optional]"
-                        value={description}
-                        onChange={e => setDescription(e.target.value)}
-                    />
+            <section>
+                <textarea
+                    className="create-desc rounded p-3 w-full outline-none resize-none bg-background dark:bg-background-dark placeholder:text-secondary dark:placeholder:text-secondary-dark placeholder:font-light"
+                    placeholder="Assignment Description [Optional]"
+                    value={description}
+                    onChange={e => setDescription(e.target.value)}
+                />
 
+                <div className="flex items-center gap-2">
+                    <PriorityPicker priority={priority} setPriority={setPriority} align='right' />
+
+                    <Popover>
+                        <Popover.Button className="py-0.5 px-1.5 rounded-sm text-[0.8rem] bg-theme dark:bg-theme-dark text-white cursor-pointer" onClick={() => setOpen(!open)}>
+                            {timestamp.toLocaleString(DateTime.TIME_SIMPLE)} on {timestamp.toLocaleString(DATE_MED_NO_YEAR)}
+                        </Popover.Button>
+                        <CalendarPopover
+                            className="inset-0 m-auto"
+                            currTime={timestamp}
+                            setTime={setTimestamp}
+                            time
+                            start={currTime.startOf('day')}
+                        />
+                    </Popover>
+                </div>
+            </section>
+
+            <section className="flex flex-wrap gap-3 items-center justify-end">
+                <OutlineButton onClick={() => setOpen(false)}>Cancel</OutlineButton>
+                <SuccessOutlineButton disabled={!ready} onClick={create}>
                     <div className="flex items-center gap-2">
-                        <PriorityPicker priority={priority} setPriority={setPriority} align='right' />
-
-                        <Popover>
-                            <Popover.Button className="py-0.5 px-1.5 rounded-sm text-[0.8rem] bg-theme dark:bg-theme-dark text-white cursor-pointer" onClick={() => setOpen(!open)}>
-                                {timestamp.toLocaleString(DateTime.TIME_SIMPLE)} on {timestamp.toLocaleString(DATE_MED_NO_YEAR)}
-                            </Popover.Button>
-                            <Transition
-                                as={Fragment}
-                                enter="ease-out duration-200 absolute inset-0 m-auto"
-                                enterFrom="opacity-0 scale-95"
-                                enterTo="opacity-100 scale-100"
-                                leave="ease-in duration-150 absolute inset-0 m-auto"
-                                leaveFrom="opacity-100 scale-100"
-                                leaveTo="opacity-0 scale-95"
-                            >
-                                <Popover.Panel>
-                                    <Calendar
-                                        className="inset-0 m-auto"
-                                        currTime={timestamp}
-                                        setTime={setTimestamp}
-                                        time
-                                        start={currTime.startOf('day')}
-                                    />
-                                </Popover.Panel>
-                            </Transition>
-                        </Popover>
+                        {item ? (<>
+                            <Edit /> Edit
+                        </>) : (<>
+                            <PlusCircle /> Create
+                        </>)}
                     </div>
-                </section>
-
-                <section className="flex flex-wrap gap-3 items-center justify-end">
-                    <OutlineButton onClick={() => setOpen(false)}>Cancel</OutlineButton>
-                    <SuccessOutlineButton disabled={!ready} onClick={create}>
-                        <div className="flex items-center gap-2">
-                            {item ? (<>
-                                <Edit /> Edit
-                            </>) : (<>
-                                <PlusCircle /> Create
-                            </>)}
-                        </div>
-                    </SuccessOutlineButton>
-                </section>
-            </div>
+                </SuccessOutlineButton>
+            </section>
         </CenteredModal>
     )
 }

--- a/client/src/components/classes/Upcoming.tsx
+++ b/client/src/components/classes/Upcoming.tsx
@@ -81,7 +81,7 @@ export default function Upcoming() {
             <div className="upcoming">
                 <ClassFilter classes={classes} filter={filter} setFilter={setFilter} />
 
-                <section className="upcoming-icons flex items-center gap-3">
+                <section className="upcoming-icons flex items-center gap-3 mb-4">
                     <button className="add-assignment" onClick={() => setCreating(!creating)}>
                         <FilePlus size={20} />
                     </button>
@@ -93,7 +93,12 @@ export default function Upcoming() {
                 </section>
 
                 {upcomingFiltered && overdueFiltered && (
-                    <Assignments upcoming={upcomingFiltered} overdue={overdueFiltered} activeItem={activeItem} setActiveItem={setActiveItem} />
+                    <Assignments
+                        upcoming={upcomingFiltered}
+                        overdue={overdueFiltered}
+                        activeItem={activeItem}
+                        setActiveItem={setActiveItem}
+                    />
                 )}
             </div>
             {screenType !== 'smallScreen' && screenType !== 'phone' && (

--- a/client/src/components/firebase/SgyInitResults.tsx
+++ b/client/src/components/firebase/SgyInitResults.tsx
@@ -59,58 +59,56 @@ export default function SgyInitResults() {
     }
 
     return (
-        <CenteredModal isOpen={sgyModal} setIsOpen={setSgyModal}>
-            <div className="relative bg-content dark:bg-content-dark rounded-md max-w-md p-6">
-                <Dialog.Title className="text-xl font-semibold mb-3">
-                    {confirmDisable ? (
-                        'Are you sure you want to disable Schoology Integration?'
-                    ) : (
-                        'You\'re almost set! Just one last step remaining.'
-                    )}
-                </Dialog.Title>
+        <CenteredModal className="relative bg-content dark:bg-content-dark rounded-md max-w-md p-6" isOpen={sgyModal} setIsOpen={setSgyModal}>
+            <Dialog.Title className="text-xl font-semibold mb-3">
+                {confirmDisable ? (
+                    'Are you sure you want to disable Schoology Integration?'
+                ) : (
+                    'You\'re almost set! Just one last step remaining.'
+                )}
+            </Dialog.Title>
 
-                <Dialog.Description as="section" className="mb-3">
-                    {!results ? (
-                        <Loading>Fetching courses...</Loading>
-                    ) : confirmDisable ? (
-                        <em className="secondary mb-3">
-                            If there was a problem, please submit an issue on Github.
-                        </em>
-                    ) : (<>
-                        <p>Your fetched periods:</p>
-                        <div className="flex flex-col gap-1.5 my-2">
-                            {/* TODO: better way to type assert this than `as {[key: string]: [string, string]}`? */}
-                            {Object.entries((results.data as {[key: string]: [string, string]})).map(([period, value]) => (
-                                <div key={period} className="flex items-center gap-2">
-                                    <span className="w-[30px] h-[30px] flex items-center justify-center bg-background dark:bg-background-dark rounded-full">{period}</span>
-                                    {value[0]} · {value[1]}
-                                </div>
-                            ))}
-                        </div>
-                        <em className="secondary">
-                            If this does not look right, disable Schoology integration and submit an issue on Github.
-                        </em>
-                    </>)}
-                </Dialog.Description>
+            <Dialog.Description as="section" className="mb-3">
+                {!results ? (
+                    <Loading>Fetching courses...</Loading>
+                ) : confirmDisable ? (
+                    <em className="secondary mb-3">
+                        If there was a problem, please submit an issue on Github.
+                    </em>
+                ) : (<>
+                    <p>Your fetched periods:</p>
+                    <div className="flex flex-col gap-1.5 my-2">
+                        {/* TODO: better way to type assert this than `as {[key: string]: [string, string]}`? */}
+                        {Object.entries((results.data as {[key: string]: [string, string]})).map(([period, value]) => (
+                            <div key={period} className="flex items-center gap-2">
+                                <span className="w-[30px] h-[30px] flex items-center justify-center bg-background dark:bg-background-dark rounded-full">{period}</span>
+                                {value[0]} · {value[1]}
+                            </div>
+                        ))}
+                    </div>
+                    <em className="secondary">
+                        If this does not look right, disable Schoology integration and submit an issue on Github.
+                    </em>
+                </>)}
+            </Dialog.Description>
 
-                <section className="flex gap-3">
-                    {results && (confirmDisable ? (<>
-                        <DangerOutlineButton onClick={disableSchoology}>
-                            Yes, Disable Schoology
-                        </DangerOutlineButton>
-                        <OutlineButton onClick={() => setConfirm(false)}>
-                            Take Me Back!
-                        </OutlineButton>
-                    </>) : (<>
-                        <DangerOutlineButton onClick={() => setConfirm(true)}>
-                            Disable Schoology
-                        </DangerOutlineButton>
-                        <SuccessOutlineButton onClick={enableSchoology}>
-                            Looks Good!
-                        </SuccessOutlineButton>
-                    </>))}
-                </section>
-            </div>
+            <section className="flex gap-3">
+                {results && (confirmDisable ? (<>
+                    <DangerOutlineButton onClick={disableSchoology}>
+                        Yes, Disable Schoology
+                    </DangerOutlineButton>
+                    <OutlineButton onClick={() => setConfirm(false)}>
+                        Take Me Back!
+                    </OutlineButton>
+                </>) : (<>
+                    <DangerOutlineButton onClick={() => setConfirm(true)}>
+                        Disable Schoology
+                    </DangerOutlineButton>
+                    <SuccessOutlineButton onClick={enableSchoology}>
+                        Looks Good!
+                    </SuccessOutlineButton>
+                </>))}
+            </section>
         </CenteredModal>
     )
 }

--- a/client/src/components/layout/AnimatedPopover.tsx
+++ b/client/src/components/layout/AnimatedPopover.tsx
@@ -7,12 +7,12 @@ export default function AnimatedPopover(props: {children: ReactNode, className?:
     return (
         <Transition
             as={Fragment}
-            enter="transition duration-150 ease-out z-20"
-            enterFrom="transform scale-95 opacity-0"
-            enterTo="transform scale-100 opacity-100"
-            leave="transition duration-100 ease-out z-20"
-            leaveFrom="transform scale-100 opacity-100"
-            leaveTo="transform scale-95 opacity-0"
+            enter="transition duration-150 ease-out"
+            enterFrom="scale-95 opacity-0"
+            enterTo="scale-100 opacity-100"
+            leave="transition duration-100 ease-out"
+            leaveFrom="scale-100 opacity-100"
+            leaveTo="scale-95 opacity-0"
         >
             <Popover.Panel className={props.className}>
                 {props.children}

--- a/client/src/components/layout/CenteredModal.tsx
+++ b/client/src/components/layout/CenteredModal.tsx
@@ -5,13 +5,13 @@ import {Dialog, Transition} from '@headlessui/react';
 // A reusable component to wrap a transition and dialog overlay around a screen-centered div.
 type CenteredModalProps = {
     isOpen: boolean, setIsOpen: (isOpen: boolean) => void,
-    children: ReactNode
+    className: string, children: ReactNode
 }
 export default function CenteredModal(props: CenteredModalProps) {
-    const {isOpen, setIsOpen, children} = props;
+    const {isOpen, setIsOpen, className, children} = props;
 
     return (
-        <Transition appear show={isOpen} as={Fragment}>
+        <Transition show={isOpen} as={Fragment}>
             <Dialog open={isOpen} onClose={() => setIsOpen(false)} className="fixed z-10 inset-0 flex items-center justify-center">
                 <Transition.Child
                     as={Fragment}
@@ -22,7 +22,7 @@ export default function CenteredModal(props: CenteredModalProps) {
                     leaveFrom="opacity-100"
                     leaveTo="opacity-0"
                 >
-                    <Dialog.Overlay className="fixed inset-0 bg-black/40" />
+                    <div className="fixed inset-0 bg-black/40" />
                 </Transition.Child>
 
                 <Transition.Child
@@ -34,7 +34,9 @@ export default function CenteredModal(props: CenteredModalProps) {
                     leaveFrom="opacity-100 scale-100"
                     leaveTo="opacity-0 scale-95"
                 >
-                    {children}
+                    <Dialog.Panel className={className}>
+                        {children}
+                    </Dialog.Panel>
                 </Transition.Child>
             </Dialog>
         </Transition>

--- a/client/src/components/layout/CenteredModal.tsx
+++ b/client/src/components/layout/CenteredModal.tsx
@@ -12,7 +12,7 @@ export default function CenteredModal(props: CenteredModalProps) {
 
     return (
         <Transition show={isOpen} as={Fragment}>
-            <Dialog open={isOpen} onClose={() => setIsOpen(false)} className="fixed z-10 inset-0 flex items-center justify-center">
+            <Dialog onClose={() => setIsOpen(false)} className="fixed z-10 inset-0 flex items-center justify-center">
                 <Transition.Child
                     as={Fragment}
                     enter="ease-out duration-300"

--- a/client/src/components/layout/Wave.tsx
+++ b/client/src/components/layout/Wave.tsx
@@ -3,7 +3,10 @@ export default function Wave() {
     const rightColor = 'eb144c';
 
     return (
-        <svg className="fixed top-0 left-0 -z-10 w-[max(800px,_100%)]" viewBox="0 0 1440 700" xmlns="http://www.w3.org/2000/svg">
+        // Constrain the width between 800px and 100vw as a hack for phone aspect ratio.
+        // 100vw is used instead of 100% to not cause the wave to shift slightly depending on the presence of
+        // a scrollbar; the wave will never cause a horizontal scrollbar so 100vw is safe.
+        <svg className="fixed top-0 left-0 -z-10 w-[max(800px,_100vw)]" viewBox="0 0 1440 700" xmlns="http://www.w3.org/2000/svg">
             <defs>
                 <linearGradient id="low">
                     <stop offset="5%" stopColor={`#${rightColor}44`}/>

--- a/client/src/components/lists/ClubComponentModal.tsx
+++ b/client/src/components/lists/ClubComponentModal.tsx
@@ -44,50 +44,48 @@ export default function ClubComponentModal(props: ClubComponentModalProps) {
         + (data ? `&entry.1448575177=${data.displayName}` : '')
 
     return (
-        <CenteredModal isOpen={isOpen} setIsOpen={setIsOpen}>
-            <div className="relative flex flex-col bg-content dark:bg-content-dark rounded-md max-w-md max-h-[90%] mx-2 p-6 shadow-xl">
-                <Dialog.Title className="text-xl font-semibold mb-3 pr-6">
-                    {name}{props.new && <Badge>New</Badge>}
-                </Dialog.Title>
-                <section className="flex gap-6 justify-between">
-                    <div className="basis-1/3">
-                        <p><strong className="secondary font-medium">Day:</strong> {day}</p>
-                        <p><strong className="secondary font-medium">Time:</strong> {time}</p>
-                        <p><strong className="secondary font-medium">Location:</strong> {room}</p>
-                    </div>
-                    <div className="text-right">
-                        <p><strong className="secondary font-medium">President(s):</strong> {prez}</p>
-                        <p><strong className="secondary font-medium">Advisor(s):</strong> {advisor}{coadvisor && ', ' + coadvisor}</p>
-                        <p><strong className="secondary font-medium">Email(s):</strong> {email}{coemail && ', ' + coemail}</p>
-                    </div>
-                </section>
-                <hr className="my-3" />
+        <CenteredModal className="relative flex flex-col bg-content dark:bg-content-dark rounded-md max-w-md max-h-[90%] mx-2 p-6 shadow-xl" isOpen={isOpen} setIsOpen={setIsOpen}>
+            <Dialog.Title className="text-xl font-semibold mb-3 pr-6">
+                {name}{props.new && <Badge>New</Badge>}
+            </Dialog.Title>
+            <section className="flex gap-6 justify-between">
+                <div className="basis-1/3">
+                    <p><strong className="secondary font-medium">Day:</strong> {day}</p>
+                    <p><strong className="secondary font-medium">Time:</strong> {time}</p>
+                    <p><strong className="secondary font-medium">Location:</strong> {room}</p>
+                </div>
+                <div className="text-right">
+                    <p><strong className="secondary font-medium">President(s):</strong> {prez}</p>
+                    <p><strong className="secondary font-medium">Advisor(s):</strong> {advisor}{coadvisor && ', ' + coadvisor}</p>
+                    <p><strong className="secondary font-medium">Email(s):</strong> {email}{coemail && ', ' + coemail}</p>
+                </div>
+            </section>
+            <hr className="my-3" />
 
-                <section className="mb-4 overflow-scroll scroll-smooth scrollbar-none">
-                    <Dialog.Description>{desc}</Dialog.Description>
-                    {video && <p><strong>Club Video:</strong> <a href={video} target="_blank" rel="noopener noreferrer" style={{wordBreak: 'break-all'}}>{video}</a></p>}
-                    {signup && <p><strong>Signup Form:</strong> <a href={signup} target="_blank" rel="noopener noreferrer" style={{wordBreak: 'break-all'}}>{signup}</a></p>}
-                    {zoom && <p><strong>Zoom Link:</strong> <a href={zoom} target="_blank" rel="noopener noreferrer" style={{wordBreak: 'break-all'}}>{zoom}</a></p>}
-                </section>
+            <section className="mb-4 overflow-scroll scroll-smooth scrollbar-none">
+                <Dialog.Description>{desc}</Dialog.Description>
+                {video && <p><strong>Club Video:</strong> <a href={video} target="_blank" rel="noopener noreferrer" style={{wordBreak: 'break-all'}}>{video}</a></p>}
+                {signup && <p><strong>Signup Form:</strong> <a href={signup} target="_blank" rel="noopener noreferrer" style={{wordBreak: 'break-all'}}>{signup}</a></p>}
+                {zoom && <p><strong>Zoom Link:</strong> <a href={zoom} target="_blank" rel="noopener noreferrer" style={{wordBreak: 'break-all'}}>{zoom}</a></p>}
+            </section>
 
-                <section className="flex gap-3 flex-wrap justify-end">
-                    {pinned ? (
-                        <OutlineButton onClick={removeFromPinned}>
-                            Remove from my list
-                        </OutlineButton>
-                    ) : (
-                        <OutlineButton onClick={addToPinned}>
-                            Add to my list
-                        </OutlineButton>
-                    )}
-                    <a href={prefilledLink} tabIndex={-1} target="_blank" rel="noopener noreferrer">
-                        <OutlineButton>Check In</OutlineButton>
-                    </a>
-                    <DangerOutlineButton onClick={() => setIsOpen(false)}>
-                        Close
-                    </DangerOutlineButton>
-                </section>
-            </div>
+            <section className="flex gap-3 flex-wrap justify-end">
+                {pinned ? (
+                    <OutlineButton onClick={removeFromPinned}>
+                        Remove from my list
+                    </OutlineButton>
+                ) : (
+                    <OutlineButton onClick={addToPinned}>
+                        Add to my list
+                    </OutlineButton>
+                )}
+                <a href={prefilledLink} tabIndex={-1} target="_blank" rel="noopener noreferrer">
+                    <OutlineButton>Check In</OutlineButton>
+                </a>
+                <DangerOutlineButton onClick={() => setIsOpen(false)}>
+                    Close
+                </DangerOutlineButton>
+            </section>
         </CenteredModal>
     )
 }

--- a/client/src/components/lists/StaffComponent.tsx
+++ b/client/src/components/lists/StaffComponent.tsx
@@ -70,43 +70,41 @@ export default function StaffComponent(props: Staff & {id: string}) {
             )}
             {email && <p className="secondary">{email}</p>}
 
-            <CenteredModal isOpen={modal} setIsOpen={setModal}>
-                <div className="relative bg-content dark:bg-content-dark rounded-md max-w-md mx-2 p-6 shadow-xl">
-                    <Dialog.Title className="text-xl font-semibold mb-3 pr-6">{name}</Dialog.Title>
-                    <section className="flex gap-6 justify-between">
-                        <div>
-                            {title && <p><strong className="secondary font-medium">Title:</strong> {title}</p>}
-                            {dept && <p><strong className="secondary font-medium">Department:</strong> {dept}</p>}
-                            {room && <p><strong className="secondary font-medium">Room:</strong> {room}</p>}
-                        </div>
-                        <div className="text-right">
-                            {email && <p><strong className="secondary font-medium">Email:</strong> {email}</p>}
-                            {phone && <p><strong className="secondary font-medium">Phone:</strong> {phone}</p>}
-                        </div>
-                    </section>
+            <CenteredModal className="relative bg-content dark:bg-content-dark rounded-md max-w-md mx-2 p-6 shadow-xl" isOpen={modal} setIsOpen={setModal}>
+                <Dialog.Title className="text-xl font-semibold mb-3 pr-6">{name}</Dialog.Title>
+                <section className="flex gap-6 justify-between">
+                    <div>
+                        {title && <p><strong className="secondary font-medium">Title:</strong> {title}</p>}
+                        {dept && <p><strong className="secondary font-medium">Department:</strong> {dept}</p>}
+                        {room && <p><strong className="secondary font-medium">Room:</strong> {room}</p>}
+                    </div>
+                    <div className="text-right">
+                        {email && <p><strong className="secondary font-medium">Email:</strong> {email}</p>}
+                        {phone && <p><strong className="secondary font-medium">Phone:</strong> {phone}</p>}
+                    </div>
+                </section>
 
-                    {charters.length > 0 && (<>
-                        <hr className="my-3" />
-                        <p className="flex gap-1 items-center">
-                            <strong className="secondary font-medium">Club(s):</strong> {charters}
-                        </p>
-                    </>)}
+                {charters.length > 0 && (<>
+                    <hr className="my-3" />
+                    <p className="flex gap-1 items-center">
+                        <strong className="secondary font-medium">Club(s):</strong> {charters}
+                    </p>
+                </>)}
 
-                    <section className="flex gap-3 flex-wrap justify-end mt-4">
-                        {pinned ? (
-                            <OutlineButton onClick={removeFromPinned}>
-                                Remove from my list
-                            </OutlineButton>
-                        ) : (
-                            <OutlineButton onClick={addToPinned}>
-                                Add to my list
-                            </OutlineButton>
-                        )}
-                        <DangerOutlineButton onClick={() => setModal(false)}>
-                            Close
-                        </DangerOutlineButton>
-                    </section>
-                </div>
+                <section className="flex gap-3 flex-wrap justify-end mt-4">
+                    {pinned ? (
+                        <OutlineButton onClick={removeFromPinned}>
+                            Remove from my list
+                        </OutlineButton>
+                    ) : (
+                        <OutlineButton onClick={addToPinned}>
+                            Add to my list
+                        </OutlineButton>
+                    )}
+                    <DangerOutlineButton onClick={() => setModal(false)}>
+                        Close
+                    </DangerOutlineButton>
+                </section>
             </CenteredModal>
         </li>
     );

--- a/client/src/components/schedule/DateSelector.tsx
+++ b/client/src/components/schedule/DateSelector.tsx
@@ -27,36 +27,40 @@ export default function DateSelector(props: DateSelectorProps) {
     const decDay = () => setViewDate(viewDate.minus({days: 1}));
 
     return (
-        <Popover className="relative z-20 mb-8 flex justify-center gap-3">
+        <div className="relative z-20 mb-8 flex justify-center gap-3">
             <button onClick={decDay}>
                 <ChevronLeft/>
             </button>
 
-            <Popover.Button className="h-9 w-56 bg-content dark:bg-content-dark flex items-center justify-center shadow-lg rounded cursor-pointer">
-                {viewDate.toLocaleString(DateTime.DATE_FULL)}
-            </Popover.Button>
-            <CalendarPopover
-                currTime={viewDate}
-                setTime={setViewDate}
-                start={start}
-                end={end}
-                className="top-[calc(100%_+_10px)]"
-            />
+            <Popover className="relative flex flex-col">
+                <Popover.Button className="h-9 w-56 bg-content dark:bg-content-dark flex items-center justify-center shadow-lg rounded cursor-pointer">
+                    {viewDate.toLocaleString(DateTime.DATE_FULL)}
+                </Popover.Button>
+                <AnimatedPopover className="flex justify-center">
+                    <Calendar
+                        className="top-[calc(100%_+_10px)]"
+                        currTime={viewDate}
+                        setTime={setViewDate}
+                        start={start}
+                        end={end}
+                    />
+                </AnimatedPopover>
+            </Popover>
 
             <button onClick={incDay}>
                 <ChevronRight/>
             </button>
-        </Popover>
+        </div>
     );
 }
 
-type CalendarPopoverProps = {
+type CalendarProps = {
     start?: DateTime, end?: DateTime,
     currTime: DateTime, setTime: (day: DateTime) => any,
     time?: boolean, // do you choose time as well?
     className?: string
 }
-export function CalendarPopover(props: CalendarPopoverProps) {
+export function Calendar(props: CalendarProps) {
     const {start, end, currTime, setTime, time, className} = props;
 
     const date = useContext(CurrentTimeContext);
@@ -133,7 +137,7 @@ export function CalendarPopover(props: CalendarPopoverProps) {
     });
 
     return (
-        <AnimatedPopover className={"w-[300px] h-max max-h-[60vh] bg-content dark:bg-content-dark z-20 rounded flex flex-col shadow-2xl absolute" + (className ? ` ${className}` : '')}>
+        <div className={"w-[300px] h-max max-h-[60vh] bg-content dark:bg-content-dark z-20 rounded flex flex-col shadow-2xl absolute" + (className ? ` ${className}` : '')}>
             {time && <TimeSelector currTime={currTime} setTime={setTime} />}
 
             <section className={'grid grid-cols-7 px-4 pt-2.5 pb-1.5 bg-content-secondary dark:bg-content-secondary-dark' + (!time ? ' rounded-t' : '')}>
@@ -150,7 +154,7 @@ export function CalendarPopover(props: CalendarPopoverProps) {
                 <button onClick={() => setTime(today)}>Today</button>
                 <button onClick={() => setTime(tmrw)}>Tomorrow</button>
             </section>
-        </AnimatedPopover>
+        </div>
     )
 }
 

--- a/client/src/components/schedule/DateSelector.tsx
+++ b/client/src/components/schedule/DateSelector.tsx
@@ -83,6 +83,9 @@ export function Calendar(props: CalendarProps) {
         wrapper.current.scrollTop = currMonth.current.offsetTop - 48 - 16;
     }, [wrapper, currMonth])
 
+    // Function to set the day without modifying the hour or minutes
+    const setDate = (day: DateTime) => setTime(currTime.set({year: day.year, ordinal: day.ordinal}));
+
     // I probably shouldn't do this here
     // generate schedule
     const weekdays = ['U', 'M', 'T', 'W', 'θ', 'F', 'S'];
@@ -123,7 +126,7 @@ export function Calendar(props: CalendarProps) {
                         return (
                             <div
                                 className={'flex items-center justify-center cursor-pointer py-0.5' + (noSchool && !active ? ' secondary' : '') + (active ? ' bg-theme dark:bg-theme-dark text-white rounded-full' : '')}
-                                onClick={() => setTime(day)}
+                                onClick={() => setDate(day)}
                                 key={day.toISO()}
                                 style={i === 0 ? {gridColumnStart: (day.weekday % 7) + 1} : undefined}
                             >
@@ -151,8 +154,8 @@ export function Calendar(props: CalendarProps) {
             </section>
 
             <section className="flex justify-between px-4 pt-1.5 pb-2.5 bg-content-secondary dark:bg-content-secondary-dark rounded-b">
-                <button onClick={() => setTime(today)}>Today</button>
-                <button onClick={() => setTime(tmrw)}>Tomorrow</button>
+                <button onClick={() => setDate(today)}>Today</button>
+                <button onClick={() => setDate(tmrw)}>Tomorrow</button>
             </section>
         </div>
     )

--- a/client/src/components/schedule/DateSelector.tsx
+++ b/client/src/components/schedule/DateSelector.tsx
@@ -27,40 +27,36 @@ export default function DateSelector(props: DateSelectorProps) {
     const decDay = () => setViewDate(viewDate.minus({days: 1}));
 
     return (
-        <div className="mb-8 flex justify-center gap-3">
+        <Popover className="relative z-20 mb-8 flex justify-center gap-3">
             <button onClick={decDay}>
                 <ChevronLeft/>
             </button>
 
-            <Popover className="h-9 w-56 bg-content dark:bg-content-dark flex flex-col relative shadow-lg rounded">
-                <Popover.Button className="w-full h-full flex items-center justify-center cursor-pointer">
-                    {viewDate.toLocaleString(DateTime.DATE_FULL)}
-                </Popover.Button>
-                <AnimatedPopover className="flex justify-center">
-                    <Calendar
-                        currTime={viewDate}
-                        setTime={setViewDate}
-                        start={start}
-                        end={end}
-                        className="top-[calc(100%_+_10px)]"
-                    />
-                </AnimatedPopover>
-            </Popover>
+            <Popover.Button className="h-9 w-56 bg-content dark:bg-content-dark flex items-center justify-center shadow-lg rounded cursor-pointer">
+                {viewDate.toLocaleString(DateTime.DATE_FULL)}
+            </Popover.Button>
+            <CalendarPopover
+                currTime={viewDate}
+                setTime={setViewDate}
+                start={start}
+                end={end}
+                className="top-[calc(100%_+_10px)]"
+            />
 
             <button onClick={incDay}>
                 <ChevronRight/>
             </button>
-        </div>
+        </Popover>
     );
 }
 
-type CalendarProps = {
+type CalendarPopoverProps = {
     start?: DateTime, end?: DateTime,
     currTime: DateTime, setTime: (day: DateTime) => any,
     time?: boolean, // do you choose time as well?
     className?: string
 }
-export function Calendar(props: CalendarProps) {
+export function CalendarPopover(props: CalendarPopoverProps) {
     const {start, end, currTime, setTime, time, className} = props;
 
     const date = useContext(CurrentTimeContext);
@@ -137,7 +133,7 @@ export function Calendar(props: CalendarProps) {
     });
 
     return (
-        <div className={"w-[300px] h-max max-h-[60vh] bg-content dark:bg-content-dark z-20 rounded flex flex-col shadow-2xl absolute" + (className ? ` ${className}` : '')}>
+        <AnimatedPopover className={"w-[300px] h-max max-h-[60vh] bg-content dark:bg-content-dark z-20 rounded flex flex-col shadow-2xl absolute" + (className ? ` ${className}` : '')}>
             {time && <TimeSelector currTime={currTime} setTime={setTime} />}
 
             <section className={'grid grid-cols-7 px-4 pt-2.5 pb-1.5 bg-content-secondary dark:bg-content-secondary-dark' + (!time ? ' rounded-t' : '')}>
@@ -154,7 +150,7 @@ export function Calendar(props: CalendarProps) {
                 <button onClick={() => setTime(today)}>Today</button>
                 <button onClick={() => setTime(tmrw)}>Tomorrow</button>
             </section>
-        </div>
+        </AnimatedPopover>
     )
 }
 

--- a/client/src/components/schedule/Event.tsx
+++ b/client/src/components/schedule/Event.tsx
@@ -53,7 +53,7 @@ export default function Event(props: GCalEvent) {
                 </Disclosure.Button>
                 <Disclosure.Panel className="flex flex-col gap-2 secondary text-sm mt-2 whitespace-pre-wrap">
                     {/* Parse away trailing whitespace, split excessive newlines into paragraph spacing */}
-                    {description.trim().split(/\n+/).map(l => <p>{l}</p>)}
+                    {description.trim().split(/(?:\n\s*)+/).map(l => <p>{l}</p>)}
                 </Disclosure.Panel>
             </>)}
         </Disclosure>

--- a/client/src/components/settings/About.tsx
+++ b/client/src/components/settings/About.tsx
@@ -1,15 +1,4 @@
-import {useEffect, useState} from 'react';
-
-
 export default function About() {
-    const [contributors, setContributors] = useState<any[] | null>(null);
-
-    useEffect(() => {
-        fetch('https://api.github.com/repos/GunnWATT/watt/contributors')
-            .then(res => res.json())
-            .then(json => setContributors(json))
-    }, [])
-
     return (
         <>
             <h1 className="mb-4">About</h1>
@@ -38,47 +27,13 @@ export default function About() {
                 Special thanks to <a href="https://github.com/mymylie" target="_blank" rel="noopener noreferrer">Mylie</a> who designed our lovely logo.
             </p>
 
-            <p className="mb-4">
-                Thank you to all of our GitHub contributors, who dedicated their time and expertise to work on
-                this project.
-            </p>
-            {contributors && (
-                <div className="flex flex-wrap justify-center gap-3 px-4 mb-4">
-                    {contributors.map((c) => (
-                        <Contributor name={c.login} href={c.html_url} src={c.avatar_url} />
-                    ))}
-                </div>
-            )}
-
-            <p className="mb-4">
-                And thank you to our testers and advisors. Your bug reports and design advice guides the continued improvement
-                of WATT as it heads into the future.
-            </p>
-            <div className="flex flex-wrap justify-center gap-x-4 gap-y-2 secondary font-light text-sm px-4 mb-4">
-                <span>Brandon Chung</span>
-                <span>Sean Yen</span>
-                <span>Timothy Herchen</span>
-                <span>Saumya Singhal</span>
-                <span>Mylie Rodrigo</span>
-                <span>Victor Dang</span>
-            </div>
-
             <p>
                 Finally, this app would not have been possible without its predecessor, <a href="https://github.com/Orbiit/gunn-web-app" target="_blank" rel="noopener noreferrer">UGWA</a>.
                 A large thank you to <a href="https://github.com/SheepTester" target="_blank" rel="noopener noreferrer">Sean</a>,
                 for not just his mentorship and guidance but for inspiring the new generation of Gunn creators to reach
-                for the stars. It is our hope that WATT can take up this mantle, fostering interest in programming for
-                years to come.
+                for the stars. It is our hope that WATT can take up this mantle, inspiring the next generation of Gunn
+                students to pursue their dreams in years to come.
             </p>
         </>
     );
-}
-
-type ContributorProps = {name: string, href: string, src: string};
-function Contributor(props: ContributorProps) {
-    return (
-        <a href={props.href} target="_blank" rel="noopener noreferrer" className="rounded-full overflow-clip hover:ring-4 hover:ring-tertiary dark:hover:ring-tertiary-dark transition duration-100">
-            <img src={props.src} alt={props.name} className="h-12 w-12" />
-        </a>
-    )
 }

--- a/client/src/components/settings/About.tsx
+++ b/client/src/components/settings/About.tsx
@@ -1,4 +1,15 @@
+import {useEffect, useState} from 'react';
+
+
 export default function About() {
+    const [contributors, setContributors] = useState<any[] | null>(null);
+
+    useEffect(() => {
+        fetch('https://api.github.com/repos/GunnWATT/watt/contributors')
+            .then(res => res.json())
+            .then(json => setContributors(json))
+    }, [])
+
     return (
         <>
             <h1 className="mb-4">About</h1>
@@ -27,11 +38,47 @@ export default function About() {
                 Special thanks to <a href="https://github.com/mymylie" target="_blank" rel="noopener noreferrer">Mylie</a> who designed our lovely logo.
             </p>
 
+            <p className="mb-4">
+                Thank you to all of our GitHub contributors, who dedicated their time and expertise to work on
+                this project.
+            </p>
+            {contributors && (
+                <div className="flex flex-wrap justify-center gap-3 px-4 mb-4">
+                    {contributors.map((c) => (
+                        <Contributor name={c.login} href={c.html_url} src={c.avatar_url} />
+                    ))}
+                </div>
+            )}
+
+            <p className="mb-4">
+                And thank you to our testers and advisors. Your bug reports and design advice guides the continued improvement
+                of WATT as it heads into the future.
+            </p>
+            <div className="flex flex-wrap justify-center gap-x-4 gap-y-2 secondary font-light text-sm px-4 mb-4">
+                <span>Brandon Chung</span>
+                <span>Sean Yen</span>
+                <span>Timothy Herchen</span>
+                <span>Saumya Singhal</span>
+                <span>Mylie Rodrigo</span>
+                <span>Victor Dang</span>
+            </div>
+
             <p>
-                This app would not have been possible without its predecessor, <a href="https://github.com/Orbiit/gunn-web-app" target="_blank" rel="noopener noreferrer">UGWA</a>.
+                Finally, this app would not have been possible without its predecessor, <a href="https://github.com/Orbiit/gunn-web-app" target="_blank" rel="noopener noreferrer">UGWA</a>.
                 A large thank you to <a href="https://github.com/SheepTester" target="_blank" rel="noopener noreferrer">Sean</a>,
-                for not just UGWA but also his mentorship and guidance of the project in its infancy.
+                for not just his mentorship and guidance but for inspiring the new generation of Gunn creators to reach
+                for the stars. It is our hope that WATT can take up this mantle, fostering interest in programming for
+                years to come.
             </p>
         </>
     );
+}
+
+type ContributorProps = {name: string, href: string, src: string};
+function Contributor(props: ContributorProps) {
+    return (
+        <a href={props.href} target="_blank" rel="noopener noreferrer" className="rounded-full overflow-clip hover:ring-4 hover:ring-tertiary dark:hover:ring-tertiary-dark transition duration-100">
+            <img src={props.src} alt={props.name} className="h-12 w-12" />
+        </a>
+    )
 }

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import {createRoot} from 'react-dom/client';
 
 // Firebase
 import FirebaseProviders from './components/firebase/FirebaseProviders';
@@ -23,15 +23,17 @@ const firebaseConfig = {
     measurementId: 'G-8EVM6G2Z8X'
 }
 
-ReactDOM.render(
+const container = document.getElementById('root')!;
+const root = createRoot(container);
+
+root.render(
     <React.StrictMode>
         <FirebaseAppProvider firebaseConfig={firebaseConfig}>
             <FirebaseProviders>
                 <App/>
             </FirebaseProviders>
         </FirebaseAppProvider>
-    </React.StrictMode>,
-    document.getElementById('root')
+    </React.StrictMode>
 );
 
 // Config for the service worker

--- a/client/src/pages/Testing.tsx
+++ b/client/src/pages/Testing.tsx
@@ -1,7 +1,8 @@
-import {ReactNode, useContext, useState} from 'react';
+import {ReactNode, useContext, useEffect, useState} from 'react';
 
 // Components
 import CenteredMessage from '../components/layout/CenteredMessage';
+import OutlineButton, {DangerOutlineButton, SuccessOutlineButton} from '../components/layout/OutlineButton';
 import Period from '../components/schedule/Period';
 import Loading from '../components/layout/Loading';
 import WIP from '../components/layout/WIP';
@@ -61,15 +62,45 @@ export default function Testing() {
     const userData = useContext(UserDataContext);
     const currTime = useContext(CurrentTimeContext);
 
+    const [contributors, setContributors] = useState<any[] | null>(null);
+
+    useEffect(() => {
+        fetch('https://api.github.com/repos/GunnWATT/watt/contributors')
+            .then(res => res.json())
+            .then(json => setContributors(json))
+    }, [])
+
     return (
         <div className="container py-6">
-            <h1>Super Secret Testing Facility</h1>
-            <p>
+            <h1 className="mb-4">Super Secret Testing Facility</h1>
+
+            <p className="mb-4">
                 Congratulations! You found the super secret testing area for Gunn WATT!
                 Experiments and other potential features will live here until they are accepted or rejected,
                 and components that only trigger conditionally (like loading screens for fetched content or period
                 components in a specific state) will stay here permanently for convenience in testing.
             </p>
+
+            <p className="mb-6">
+                While we're here, I'd like to extend a thank you to all of our GitHub contributors, testers, and advisors,
+                who dedicated their time and expertise to work on this project. Your bug fixes and design advice guides
+                the continued improvement of WATT as it heads into the future. The following people made WATT possible:
+            </p>
+            {contributors && (
+                <div className="flex flex-wrap justify-center gap-3 px-4 mb-4">
+                    {contributors.map((c) => (
+                        <Contributor name={c.login} href={c.html_url} src={c.avatar_url} />
+                    ))}
+                </div>
+            )}
+            <div className="flex flex-wrap justify-center gap-x-4 gap-y-2 secondary font-light text-sm px-4 mb-4">
+                <span>Brandon Chung</span>
+                <span>Sean Yen</span>
+                <span>Timothy Herchen</span>
+                <span>Saumya Singhal</span>
+                <span>Mylie Rodrigo</span>
+                <span>Victor Dang</span>
+            </div>
             <hr/>
 
             <main className="flex flex-col gap-4">
@@ -92,6 +123,12 @@ export default function Testing() {
 
                 <ContentBox>
                     <SgySignInBtn />
+                </ContentBox>
+
+                <ContentBox className="flex gap-2 justify-center">
+                    <OutlineButton>Add to my list</OutlineButton>
+                    <DangerOutlineButton>Disable Schoology</DangerOutlineButton>
+                    <SuccessOutlineButton>Looks good!</SuccessOutlineButton>
                 </ContentBox>
 
                 <ContentBox>
@@ -168,10 +205,19 @@ export default function Testing() {
     )
 }
 
-function ContentBox(props: {children: ReactNode}) {
+function ContentBox(props: {children: ReactNode, className?: string}) {
     return (
-        <section className="p-5 rounded-lg bg-content dark:bg-content-dark shadow-lg">
+        <section className={'p-5 rounded-lg bg-content dark:bg-content-dark shadow-lg' + (props.className ? ` ${props.className}` : '')}>
             {props.children}
         </section>
+    )
+}
+
+type ContributorProps = {name: string, href: string, src: string};
+function Contributor(props: ContributorProps) {
+    return (
+        <a href={props.href} target="_blank" rel="noopener noreferrer" className="rounded-full overflow-clip hover:ring-4 hover:ring-tertiary dark:hover:ring-tertiary-dark transition duration-100">
+            <img src={props.src} alt={props.name} className="h-12 w-12" />
+        </a>
     )
 }

--- a/client/src/styles/partials/classes/_assignments.scss
+++ b/client/src/styles/partials/classes/_assignments.scss
@@ -40,8 +40,3 @@
     }
   }
 }
-
-// Upcoming Assignments
-.upcoming-assignment {
-  margin-bottom: 10px;
-}

--- a/client/src/styles/partials/classes/_sidebar-calendar.scss
+++ b/client/src/styles/partials/classes/_sidebar-calendar.scss
@@ -4,10 +4,8 @@
   margin: 15px;
   position: sticky;
   top: 5px;
-  height: 80vh;
   border-radius: 5px;
   background-color: var(--bg-primary);
-  overflow-y: scroll;
 }
 
 .upcoming-cal-tooltip {

--- a/client/src/styles/partials/classes/_upcoming.scss
+++ b/client/src/styles/partials/classes/_upcoming.scss
@@ -2,19 +2,12 @@
 
 .upcoming-burrito {
   display: flex;
-  flex-direction: row;
-  flex-grow: 1;
   margin: -15px;
 }
 
 .upcoming {
   flex: 1;
   margin: 15px;
-}
-
-.upcoming-day-header {
-  margin: 10px 0;
-  font-size: 1.1rem;
 }
 
 .upcoming-overdue-header {


### PR DESCRIPTION
This is a bit of a mess.

#### Problems with our code, probably:
- [x] Stacking context problems with `transform` galore; transition end state classnames being persistent caused `DateSelector` to render under periods and no-school images, and I'm unsure if my patch is the most ideal way to fix it.
- [x] Related to the above (and also an issue existing on main): hovering a priority picker in `Upcoming` causes it to render below the priority picker button on a lower assignment. See https://discordapp.com/channels/795043639214604370/796534011568062464/961005542715846776
- [x] Clicking on the (recently fixed) timepicker in `CreateAssignmentModal` either closes the modal or causes something to crash with the effect of closing the modal.
- [x] The autoscroll in `CalendarPopover` is currently broken, perhaps due to refs? Needs more testing.

#### Problems with dependencies:
- [x] `react-responsive` isn't responsive on React 18 https://github.com/yocontra/react-responsive/issues/293
- [x] `AnimatedPopover` closes when clicked on the inside in React 18 https://github.com/tailwindlabs/headlessui/issues/1407 (currently using insiders build to get around this)
- [x] `CenteredModal` doesn't play its close animation on `headlessui` 1.6.0+ (though the lack of an issue about this implies to me that our old transitions were just bad and some small behavior change which isn't affecting anyone else has caused it to die)

If we get things figured out, this is definitely a good change, but at least a few things are waiting on dependencies to introduce React 18 support.