### PR TITLE
WATT API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ Navigate to the functions directory with `cd functions` and install the necessar
 Before starting the emulators (and after changing any code), compile the TypeScript source files with `npm run build`.
 **If you change the functions code, you will have to run build again.**
 
-From the root directory (`cd ..`), running `firebase emulators:start --import ./functions/presets`
-in a new terminal window should start the emulator suite UI on `localhost:4001` as well as the Firestore, Functions, and Auth
+From the root directory (`cd ..`), running 
+```
+firebase emulators:start --import ./functions/presets
+```
+in a new terminal window should start the emulator suite UI on `localhost:4000` as well as the Firestore, Functions, and Auth
 emulators on other localhost ports.
 
 ![image](https://user-images.githubusercontent.com/60120929/161687556-d3cd9682-fe90-4deb-9258-522895443ff6.png)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,13 +13,27 @@ to WATT's current alternate schedules.
 ```
 
 ### GET /schedule
-Returns a [`Schedule`](https://github.com/GunnWATT/watt/blob/api/docs/types.md#schedule) object of the current day's 
-schedule, and a boolean indicating whether the schedule is an alternate. This information is returned as
+Returns a [`Schedule`](https://github.com/GunnWATT/watt/blob/api/docs/types.md#schedule) object corresponding to the 
+requested day's schedule, and a boolean indicating whether that schedule is an alternate. This information is returned as
 ```ts
 {periods: Schedule, alternate: boolean}
 ```
 
+| Parameter           | Type     | Description                                                                                                             |
+|---------------------|----------|-------------------------------------------------------------------------------------------------------------------------|
+| `date` *(optional)* | `string` | An ISO timestamp representing the day to return the schedule for. If no date is provided, the current day will be used. |
+
+| Status code | Description                                                                 |
+|-------------|-----------------------------------------------------------------------------|
+| 200         | OK                                                                          |
+| 400         | `query.date` was provided but not a string, or invalid as an ISO timestamp. |
+
 ##### Example successful response:
 ```json
 {"periods": null, "alternate": false}
+```
+
+##### Example error response:
+```json
+{"message": "Error parsing date string: the input \"aaa\" can't be parsed as ISO 8601."}
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,2 +1,25 @@
 # WATT API Docs
-[...]
+Welcome to WATT's API documentation! Information about the endpoints exposed by the API can be found here.
+The base URL for WATT's REST API is `gunnwatt.web.app/api`.
+
+### GET /alternates
+<!-- TODO: replace all these URLs with ones linking to `main` when the PR is merged -->
+Returns an [`Alternates`](https://github.com/GunnWATT/watt/blob/api/docs/types.md#alternates) object corresponding
+to WATT's current alternate schedules.
+
+##### Example successful response:
+```json
+{"alternates": {}, "timestamp": "2022-04-30T19:15:30.052Z"}
+```
+
+### GET /schedule
+Returns a [`Schedule`](https://github.com/GunnWATT/watt/blob/api/docs/types.md#schedule) object of the current day's 
+schedule, and a boolean indicating whether the schedule is an alternate. This information is returned as
+```ts
+{periods: Schedule, alternate: boolean}
+```
+
+##### Example successful response:
+```json
+{"periods": null, "alternate": false}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,14 +14,22 @@ to WATT's current alternate schedules.
 
 ### GET /schedule
 Returns a [`Schedule`](https://github.com/GunnWATT/watt/blob/api/docs/types.md#schedule) object corresponding to the 
-requested day's schedule, and a boolean indicating whether that schedule is an alternate. This information is returned as
+requested day's schedule, and a boolean indicating whether that schedule is an alternate.
+
+##### Response schema
 ```ts
 {periods: Schedule, alternate: boolean}
 ```
+- `periods`: The day's [`Schedule`](https://github.com/GunnWATT/watt/blob/api/docs/types.md#schedule).
+- `alternate`: Whether that schedule is an alternate.
+
+##### Request parameters
 
 | Parameter           | Type     | Description                                                                                                             |
 |---------------------|----------|-------------------------------------------------------------------------------------------------------------------------|
 | `date` *(optional)* | `string` | An ISO timestamp representing the day to return the schedule for. If no date is provided, the current day will be used. |
+
+##### HTTP status codes
 
 | Status code | Description                                                                 |
 |-------------|-----------------------------------------------------------------------------|
@@ -35,5 +43,52 @@ requested day's schedule, and a boolean indicating whether that schedule is an a
 
 ##### Example error response:
 ```json
-{"message": "Error parsing date string: the input \"aaa\" can't be parsed as ISO 8601."}
+{"error": "Error parsing date string: the input \"aaa\" can't be parsed as ISO 8601."}
+```
+
+### GET /next-period
+Returns a [`PeriodObj`](https://github.com/GunnWATT/watt/blob/api/docs/types.md#periodobj) corresponding to the next or 
+current period, the period immediately before it, and additional information for displaying those periods.
+
+##### Response schema
+```ts
+{prev: PeriodObj | null, next: PeriodObj | null, startingIn: number, endingIn: number, nextSeconds: number}
+```
+- `prev`: A [`PeriodObj`](https://github.com/GunnWATT/watt/blob/api/docs/types.md#periodobj) corresponding to the previous
+  period, or `null` if there is none.
+- `next`: A [`PeriodObj`](https://github.com/GunnWATT/watt/blob/api/docs/types.md#periodobj) corresponding to the next or
+  current period, or `null` is there is none.
+- `startingIn`: The minutes until the `next` period starts, rounded down (if there is less than a minute left, this is `0`). 
+  If the period has already started, this is negative. If there is no next period, this is `0`.
+- `endingIn`: The minutes until the `next` period ends, rounded down. If there is no next period, this is `0`.
+- `nextSeconds`: The seconds left in the current minute of the provided timestamp. When `startingIn` or `endingIn` are `0`
+  and `next` is not null, you can use this to display `"ending in {...} seconds"` instead of `"ending in 0 minutes"`.
+
+##### Request parameters
+
+| Parameter           | Type     | Description                                                                                                                                 |
+|---------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `date` *(optional)* | `string` | An ISO timestamp representing the date and time to get the next period for. If no date is provided, the current date and time will be used. |
+
+##### HTTP status codes
+
+| Status code | Description                                                                 |
+|-------------|-----------------------------------------------------------------------------|
+| 200         | OK                                                                          |
+| 400         | `query.date` was provided but not a string, or invalid as an ISO timestamp. |
+
+##### Example successful response:
+```json
+{
+  "prev": {"n": "B", "s": 635, "e": 640},
+  "next": {"n": "6", "s": 650, "e": 740},
+  "startingIn": 7,
+  "endingIn": 97,
+  "nextSeconds": 23
+}
+```
+
+##### Example error response:
+```json
+{"error": "Error parsing date string: the input \"aaa\" can't be parsed as ISO 8601."}
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,2 @@
+# WATT API Docs
+[...]

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,3 +92,43 @@ current period, the period immediately before it, and additional information for
 ```json
 {"error": "Error parsing date string: the input \"aaa\" can't be parsed as ISO 8601."}
 ```
+
+### GET /next-period-message
+Returns a string containing information about the next period. Equivalent to fetching `/next-period` and returning
+```ts
+"{period} is {starting | ending} in {...} {minutes | seconds}, started {...} {minutes | seconds} ago."
+```
+if `next` has started and
+```ts
+"{period} is {starting | ending} in {...} {minutes | seconds}."
+```
+if it has not.
+
+##### Response schema
+```ts
+{message: string | null}
+```
+- `message`: The message, or `null` if there is no next period.
+
+##### Request parameters
+
+| Parameter           | Type     | Description                                                                                                                                 |
+|---------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `date` *(optional)* | `string` | An ISO timestamp representing the date and time to get the next period for. If no date is provided, the current date and time will be used. |
+
+##### HTTP status codes
+
+| Status code | Description                                                                 |
+|-------------|-----------------------------------------------------------------------------|
+| 200         | OK                                                                          |
+| 400         | `query.date` was provided but not a string, or invalid as an ISO timestamp. |
+
+##### Example successful response:
+```json
+{"message": "Period 6 ending in 87 minutes, started 3 minutes ago."}
+```
+
+##### Example error response:
+```json
+{"error": "Error parsing date string: the input \"aaa\" can't be parsed as ISO 8601."}
+```

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,50 @@
+# API Types
+
+The full reference for all types WATT's API can return are below:
+
+### `PeriodObj`
+An object representing a class period.
+```ts
+type PeriodObj = {n: string, s: number, e: number, note?: string};
+```
+##### Reference: [`/client/src/components/schedule/Periods.tsx`](https://github.com/GunnWATT/watt/blob/main/client/src/components/schedule/Periods.tsx#L24)
+
+##### Specifications:
+- `n`: The name of the period. This will be a string corresponding to one of the following:
+
+| Name                           | Description                                                                                                                                   |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `'0'`, `'1'`, `'2'`, ... `'8'` | The period corresponding to the given number. `'1'` is 1st period, `'2'` is 2nd, etc.                                                         |
+| `'B'`                          | Brunch.                                                                                                                                       |
+| `'L'`                          | Lunch.                                                                                                                                        |
+| `'S'`                          | SELF.                                                                                                                                         |
+| `'P'`                          | PRIME.                                                                                                                                        |
+| `'G'`                          | Gunn Together. *(deprecated)*                                                                                                                 |
+| `'O'`                          | Office hours. *(deprecated)*                                                                                                                  |
+| Any other string               | An unrecognized period. This can be a one-off period such as `'Title IX Lesson'`, or a recurring but unsupported period such as `'Math CAT'`. |
+
+- `s`: The start time of the period, in minutes after `12:00 AM` in the timezone `America/Los_Angeles`.
+- `e`: The end time of the period, in minutes after `12:00 AM` in the timezone `America/Los_Angeles`.
+- `note`?: An optional note with more details about the period.
+
+### `Schedule`
+An object representing a day's schedule. It is either an array of `PeriodObj`s or `null`, if there is no school on that day.
+```ts
+type Schedule = PeriodObj[] | null;
+```
+
+### `Alternates`
+`Alternates` represents an alternates object. It contains a `timestamp` representing the last time alternates were
+generated from the iCal, and an `alternates` object with string keys corresponding to the alternate schedule on that day.
+```ts
+type Alternates = {
+    timestamp: string,
+    alternates: {[key: string]: Schedule}
+}
+```
+##### Reference: [`/client/src/contexts/AlternatesContext.ts`](https://github.com/GunnWATT/watt/blob/main/client/src/contexts/AlternatesContext.ts#L5-L8)
+
+##### Specifications:
+- `timestamp`: The ISO timestamp of the last run of [`/scripts/deployAlternates`](https://github.com/GunnWATT/watt/tree/main/scripts#deploy-alternates).
+- `alternates`: An object with date keys corresponding to the alternate schedule on that day. Keys of this object are in
+  the format `MM-DD` (ex. `January 15` would be `01-15`).

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,15 +1,14 @@
 # API Types
-
-The full reference for all types WATT's API can return are below:
+The full reference for all types referenced in WATT's API can be found below:
 
 ### `PeriodObj`
 An object representing a class period.
 ```ts
 type PeriodObj = {n: string, s: number, e: number, note?: string};
 ```
-##### Reference: [`/client/src/components/schedule/Periods.tsx`](https://github.com/GunnWATT/watt/blob/main/client/src/components/schedule/Periods.tsx#L24)
+#### Reference: [`/client/src/components/schedule/Periods.tsx`](https://github.com/GunnWATT/watt/blob/main/client/src/components/schedule/Periods.tsx#L24)
 
-##### Specifications:
+#### Specifications:
 - `n`: The name of the period. This will be a string corresponding to one of the following:
 
 | Name                           | Description                                                                                                                                   |
@@ -27,10 +26,33 @@ type PeriodObj = {n: string, s: number, e: number, note?: string};
 - `e`: The end time of the period, in minutes after `12:00 AM` in the timezone `America/Los_Angeles`.
 - `note`?: An optional note with more details about the period.
 
+#### Example:
+```json
+{"n": "1", "s": 540, "e": 585}
+```
+
 ### `Schedule`
-An object representing a day's schedule. It is either an array of `PeriodObj`s or `null`, if there is no school on that day.
+An object representing a day's schedule. The `Schedule` comprises an array of `PeriodObj`s, or `null` if there is no 
+school on that day.
 ```ts
 type Schedule = PeriodObj[] | null;
+```
+
+#### Example:
+```json
+[
+    {"n": "0", "s": 475, "e": 530},
+    {"n": "1", "s": 540, "e": 585},
+    {"n": "2", "s": 595, "e": 640},
+    {"n": "B", "s": 640, "e": 645},
+    {"n": "3", "s": 655, "e": 700},
+    {"n": "4", "s": 710, "e": 755},
+    {"n": "L", "s": 755, "e": 785},
+    {"n": "5", "s": 795, "e": 840},
+    {"n": "6", "s": 850, "e": 895},
+    {"n": "7", "s": 905, "e": 950},
+    {"n": "8", "s": 960, "e": 1005}
+]
 ```
 
 ### `Alternates`
@@ -42,9 +64,14 @@ type Alternates = {
     alternates: {[key: string]: Schedule}
 }
 ```
-##### Reference: [`/client/src/contexts/AlternatesContext.ts`](https://github.com/GunnWATT/watt/blob/main/client/src/contexts/AlternatesContext.ts#L5-L8)
+#### Reference: [`/client/src/contexts/AlternatesContext.ts`](https://github.com/GunnWATT/watt/blob/main/client/src/contexts/AlternatesContext.ts#L5-L8)
 
-##### Specifications:
+#### Specifications:
 - `timestamp`: The ISO timestamp of the last run of [`/scripts/deployAlternates`](https://github.com/GunnWATT/watt/tree/main/scripts#deploy-alternates).
-- `alternates`: An object with date keys corresponding to the alternate schedule on that day. Keys of this object are in
-  the format `MM-DD` (ex. `January 15` would be `01-15`).
+- `alternates`: An object with date keys corresponding to the alternate schedule on that day, if any exist. Keys of this 
+  object are specified in the format `MM-DD` (ex. `January 15` would be `01-15`).
+
+#### Example:
+```json
+{"alternates": {}, "timestamp": "2022-04-30T19:15:30.052Z"}
+```

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,7 +1,7 @@
 # API Types
 The full reference for all types referenced in WATT's API can be found below:
 
-### `PeriodObj`
+### PeriodObj
 An object representing a class period.
 ```ts
 type PeriodObj = {n: string, s: number, e: number, note?: string};
@@ -31,9 +31,9 @@ type PeriodObj = {n: string, s: number, e: number, note?: string};
 {"n": "1", "s": 540, "e": 585}
 ```
 
-### `Schedule`
-An object representing a day's schedule. The `Schedule` comprises an array of `PeriodObj`s, or `null` if there is no 
-school on that day.
+### Schedule
+An object representing a day's schedule. The `Schedule` comprises an array of `PeriodObj`s representing the day's periods, 
+or `null` if there is no school on that day.
 ```ts
 type Schedule = PeriodObj[] | null;
 ```
@@ -42,22 +42,18 @@ type Schedule = PeriodObj[] | null;
 ```json
 [
     {"n": "0", "s": 475, "e": 530},
-    {"n": "1", "s": 540, "e": 585},
-    {"n": "2", "s": 595, "e": 640},
-    {"n": "B", "s": 640, "e": 645},
-    {"n": "3", "s": 655, "e": 700},
-    {"n": "4", "s": 710, "e": 755},
-    {"n": "L", "s": 755, "e": 785},
-    {"n": "5", "s": 795, "e": 840},
-    {"n": "6", "s": 850, "e": 895},
-    {"n": "7", "s": 905, "e": 950},
-    {"n": "8", "s": 960, "e": 1005}
+    {"n": "5", "s": 540, "e": 635},
+    {"n": "B", "s": 635, "e": 640},
+    {"n": "6", "s": 650, "e": 740},
+    {"n": "L", "s": 740, "e": 770},
+    {"n": "7", "s": 780, "e": 870},
+    {"n": "P", "s": 880, "e": 930}
 ]
 ```
 
-### `Alternates`
-`Alternates` represents an alternates object. It contains a `timestamp` representing the last time alternates were
-generated from the iCal, and an `alternates` object with string keys corresponding to the alternate schedule on that day.
+### Alternates
+An alternates object, containing a `timestamp` of the last time alternates were generated from the iCal and an object with 
+date-string keys corresponding to the alternate `Schedule` on that day.
 ```ts
 type Alternates = {
     timestamp: string,

--- a/docs/types.md
+++ b/docs/types.md
@@ -6,7 +6,8 @@ An object representing a class period.
 ```ts
 type PeriodObj = {n: string, s: number, e: number, note?: string};
 ```
-#### Reference: [`/client/src/components/schedule/Periods.tsx`](https://github.com/GunnWATT/watt/blob/main/client/src/components/schedule/Periods.tsx#L24)
+#### Reference: 
+[`/client/src/components/schedule/Periods.tsx`](https://github.com/GunnWATT/watt/blob/main/client/src/components/schedule/Periods.tsx#L24)
 
 #### Specifications:
 - `n`: The name of the period. This will be a string corresponding to one of the following:
@@ -60,7 +61,8 @@ type Alternates = {
     alternates: {[key: string]: Schedule}
 }
 ```
-#### Reference: [`/client/src/contexts/AlternatesContext.ts`](https://github.com/GunnWATT/watt/blob/main/client/src/contexts/AlternatesContext.ts#L5-L8)
+#### Reference: 
+[`/client/src/contexts/AlternatesContext.ts`](https://github.com/GunnWATT/watt/blob/main/client/src/contexts/AlternatesContext.ts#L5-L8)
 
 #### Specifications:
 - `timestamp`: The ISO timestamp of the last run of [`/scripts/deployAlternates`](https://github.com/GunnWATT/watt/tree/main/scripts#deploy-alternates).

--- a/firebase.json
+++ b/firebase.json
@@ -8,6 +8,10 @@
     ],
     "rewrites": [
       {
+        "source": "/api/**",
+        "function": "api"
+      },
+      {
         "source": "/sgyauth/**",
         "function": "sgyauth"
       },

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,10 +9,12 @@
         "express": "^4.18.1",
         "firebase-admin": "^11.0.0",
         "firebase-functions": "^3.22.0",
+        "luxon": "^3.0.1",
         "node-fetch": "^2.6.7",
         "oauth": "^0.9.15"
       },
       "devDependencies": {
+        "@types/luxon": "^3.0.0",
         "@types/node": "^18.0.6",
         "@types/oauth": "^0.9.1",
         "typescript": "^4.7.3"
@@ -360,6 +362,12 @@
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "optional": true
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.0.0.tgz",
+      "integrity": "sha512-Lx+EZoJxUKw4dp8uei9XiUVNlgkYmax5+ovqt6Xf3LzJOnWhlfJw/jLBmqfGVwOP/pDr4HT8bI1WtxK0IChMLw==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -1579,6 +1587,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
+    "node_modules/luxon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
+      "integrity": "sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -2613,6 +2629,12 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "optional": true
     },
+    "@types/luxon": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.0.0.tgz",
+      "integrity": "sha512-Lx+EZoJxUKw4dp8uei9XiUVNlgkYmax5+ovqt6Xf3LzJOnWhlfJw/jLBmqfGVwOP/pDr4HT8bI1WtxK0IChMLw==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -3589,6 +3611,11 @@
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
       }
+    },
+    "luxon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
+      "integrity": "sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,44 +6,30 @@
     "": {
       "name": "functions",
       "dependencies": {
-        "@types/node": "^17.0.5",
-        "@types/oauth": "^0.9.1",
-        "firebase-admin": "^10.2.0",
-        "firebase-functions": "^3.21.2",
+        "express": "^4.18.1",
+        "firebase-admin": "^11.0.0",
+        "firebase-functions": "^3.22.0",
         "node-fetch": "^2.6.7",
         "oauth": "^0.9.15"
       },
       "devDependencies": {
+        "@types/node": "^18.0.6",
+        "@types/oauth": "^0.9.1",
         "typescript": "^4.7.3"
       },
       "engines": {
         "node": "14"
       }
     },
-    "node_modules/@firebase/app": {
-      "version": "0.7.25",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.25.tgz",
-      "integrity": "sha512-OemDA3NZS1oEbAPFlWHeVI8Od26ZHAXUivUWFYIsYrw+YjS7FloltwyHB06Q8LQyPJIBPubGkEuzNTHz32EDCQ==",
-      "peer": true,
+    "node_modules/@fastify/busboy": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-1.1.0.tgz",
+      "integrity": "sha512-Fv854f94v0CzIDllbY3i/0NJPNBRNLDawf3BTYVGCe9VrIIs3Wi7AFx24F9NzCxdf0wyx/x0Q9kEVnvDOPnlxA==",
       "dependencies": {
-        "@firebase/component": "0.5.14",
-        "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.6.0",
-        "idb": "7.0.1",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@firebase/app-compat": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.26.tgz",
-      "integrity": "sha512-i5UTq1HZAHuhe7RNjgFSezbow4jVxc2oe3Gndsv+Hdut92f8L0AyssOtdU2iOylLlxbTijewAXXui4FAUzXubw==",
-      "peer": true,
-      "dependencies": {
-        "@firebase/app": "0.7.25",
-        "@firebase/component": "0.5.14",
-        "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.6.0",
-        "tslib": "^2.1.0"
+        "text-decoding": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/@firebase/app-types": {
@@ -61,116 +47,69 @@
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.14.tgz",
-      "integrity": "sha512-ct2p1MTMV5P/nGIlkC3XjAVwHwjsIZaeo8JVyDAkJCNTROu5mYX3FBK16hjIUIIVJDpgnnzFh9nP74gciL4WrA==",
-      "peer": true,
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.17.tgz",
+      "integrity": "sha512-mTM5CBSIlmI+i76qU4+DhuExnWtzcPS3cVgObA3VAjliPPr3GrUlTaaa8KBGfxsD27juQxMsYA0TvCR5X+GQ3Q==",
       "dependencies": {
-        "@firebase/util": "1.6.0",
+        "@firebase/util": "1.6.3",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database": {
-      "version": "0.12.8",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.12.8.tgz",
-      "integrity": "sha512-JBQVfFLzfhxlQbl4OU6ov9fdsddkytBQdtSSR49cz48homj38ccltAhK6seum+BI7f28cV2LFHF9672lcN+qxA==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.13.3.tgz",
+      "integrity": "sha512-ZE+QJqQUaCTZiIzGq3RJLo64HRMtbdaEwyDhfZyPEzMJV4kyLsw3cHdEHVCtBmdasTvwtpO2YRFmd4AXAoKtNw==",
       "dependencies": {
         "@firebase/auth-interop-types": "0.1.6",
-        "@firebase/component": "0.5.13",
-        "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.5.2",
+        "@firebase/component": "0.5.17",
+        "@firebase/logger": "0.3.3",
+        "@firebase/util": "1.6.3",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.1.8.tgz",
-      "integrity": "sha512-dhXr5CSieBuKNdU96HgeewMQCT9EgOIkfF1GNy+iRrdl7BWLxmlKuvLfK319rmIytSs/vnCzcD9uqyxTeU/A3A==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.2.3.tgz",
+      "integrity": "sha512-uwSMnbjlSQM5gQRq8OoBLs7uc7obwsl0D6kSDAnMOlPtPl9ert79Rq9faU/COjybsJ8l7tNXMVYYJo3mQ5XNrA==",
       "dependencies": {
-        "@firebase/component": "0.5.13",
-        "@firebase/database": "0.12.8",
-        "@firebase/database-types": "0.9.7",
-        "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.5.2",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/database-compat/node_modules/@firebase/component": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.13.tgz",
-      "integrity": "sha512-hxhJtpD8Ppf/VU2Rlos6KFCEV77TGIGD5bJlkPK1+B/WUe0mC6dTjW7KhZtXTc+qRBp9nFHWcsIORnT8liHP9w==",
-      "dependencies": {
-        "@firebase/util": "1.5.2",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@firebase/database-compat/node_modules/@firebase/database-types": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.7.tgz",
-      "integrity": "sha512-EFhgL89Fz6DY3kkB8TzdHvdu8XaqqvzcF2DLVOXEnQ3Ms7L755p5EO42LfxXoJqb9jKFvgLpFmKicyJG25WFWw==",
-      "dependencies": {
-        "@firebase/app-types": "0.7.0",
-        "@firebase/util": "1.5.2"
-      }
-    },
-    "node_modules/@firebase/database-compat/node_modules/@firebase/util": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.5.2.tgz",
-      "integrity": "sha512-YvBH2UxFcdWG2HdFnhxZptPl2eVFlpOyTH66iDo13JPEYraWzWToZ5AMTtkyRHVmu7sssUpQlU9igy1KET7TOw==",
-      "dependencies": {
+        "@firebase/component": "0.5.17",
+        "@firebase/database": "0.13.3",
+        "@firebase/database-types": "0.9.11",
+        "@firebase/logger": "0.3.3",
+        "@firebase/util": "1.6.3",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.8.tgz",
-      "integrity": "sha512-bI7bwF5xc0nPi6Oa3JVt6JJdfhVAnEpCwgfTNILR4lYDPtxdxlRXhZzQ5lfqlCj7PR+drKh9RvMu6C24N1q04w==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.11.tgz",
+      "integrity": "sha512-27V3eFomWCZqLR6qb3Q9eS2lsUtulhSHeDNaL6fImwnhvMYTmf6ZwMfRWupgi8AFwW4s91g9Oc1/fkQtJGHKQw==",
       "dependencies": {
         "@firebase/app-types": "0.7.0",
-        "@firebase/util": "1.6.0"
-      }
-    },
-    "node_modules/@firebase/database/node_modules/@firebase/component": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.13.tgz",
-      "integrity": "sha512-hxhJtpD8Ppf/VU2Rlos6KFCEV77TGIGD5bJlkPK1+B/WUe0mC6dTjW7KhZtXTc+qRBp9nFHWcsIORnT8liHP9w==",
-      "dependencies": {
-        "@firebase/util": "1.5.2",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@firebase/database/node_modules/@firebase/util": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.5.2.tgz",
-      "integrity": "sha512-YvBH2UxFcdWG2HdFnhxZptPl2eVFlpOyTH66iDo13JPEYraWzWToZ5AMTtkyRHVmu7sssUpQlU9igy1KET7TOw==",
-      "dependencies": {
-        "tslib": "^2.1.0"
+        "@firebase/util": "1.6.3"
       }
     },
     "node_modules/@firebase/logger": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.2.tgz",
-      "integrity": "sha512-lzLrcJp9QBWpo40OcOM9B8QEtBw2Fk1zOZQdvv+rWS6gKmhQBCEMc4SMABQfWdjsylBcDfniD1Q+fUX1dcBTXA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.3.tgz",
+      "integrity": "sha512-POTJl07jOKTOevLXrTvJD/VZ0M6PnJXflbAh5J9VGkmtXPXNG6MdZ9fmRgqYhXKTaDId6AQenQ262uwgpdtO0Q==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.6.0.tgz",
-      "integrity": "sha512-6+hhqb4Zzjoo12xofTDHPkgW3FnN4ydBsjd5X2KuQI268DR3W3Ld64W/gkKPZrKRgUxeNeb+pykfP3qRe7q+vA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.6.3.tgz",
+      "integrity": "sha512-FujteO6Zjv6v8A4HS+t7c+PjU0Kaxj+rOnka0BsI/twUaCC9t8EQPmXpWZdk7XfszfahJn2pqsflUWUhtUkRlg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@google-cloud/firestore": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-4.15.1.tgz",
-      "integrity": "sha512-2PWsCkEF1W02QbghSeRsNdYKN1qavrHBP3m72gPDMHQSYrGULOaTi7fSJquQmAtc4iPVB2/x6h80rdLHTATQtA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-5.0.2.tgz",
+      "integrity": "sha512-xlGcNYaW0nvUMzNn2+pLfbEBVt6oysVqtM89faMgZWkWfEtvIQGS0h5PRdLlcqufNzRCX3yIGv29Pb+03ys+VA==",
       "optional": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -196,61 +135,58 @@
       }
     },
     "node_modules/@google-cloud/projectify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.1.tgz",
-      "integrity": "sha512-+rssMZHnlh0twl122gXY4/aCrk0G1acBqkHFfYddtsqpYXGxA29nj9V5V9SfC+GyOG00l650f6lG9KL+EpFEWQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
+      "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
       "optional": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@google-cloud/promisify": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz",
-      "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.0.tgz",
+      "integrity": "sha512-91ArYvRgXWb73YvEOBMmOcJc0bDRs5yiVHnqkwoG0f3nm7nZuipllz6e7BvFESBvjkDTBC0zMD8QxedUwNLc1A==",
       "optional": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "5.20.5",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.20.5.tgz",
-      "integrity": "sha512-lOs/dCyveVF8TkVFnFSF7IGd0CJrTm91qiK6JLu+Z8qiT+7Ag0RyVhxZIWkhiACqwABo7kSHDm8FdH8p2wxSSw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.2.3.tgz",
+      "integrity": "sha512-UJqn3Ln8wFBPLuwBaNu3PlhzQDL3EKKfP1+3mzLRQhcFqgpBSMPLDgAXxc6e9S0l0kqsi4GOuAA7fA+l/VAMjQ==",
       "optional": true,
       "dependencies": {
         "@google-cloud/paginator": "^3.0.7",
-        "@google-cloud/projectify": "^2.0.0",
-        "@google-cloud/promisify": "^2.0.0",
+        "@google-cloud/projectify": "^3.0.0",
+        "@google-cloud/promisify": "^3.0.0",
         "abort-controller": "^3.0.0",
         "arrify": "^2.0.0",
         "async-retry": "^1.3.3",
         "compressible": "^2.0.12",
-        "configstore": "^5.0.0",
         "duplexify": "^4.0.0",
         "ent": "^2.2.0",
         "extend": "^3.0.2",
-        "gaxios": "^4.0.0",
-        "google-auth-library": "^7.14.1",
-        "hash-stream-validation": "^0.2.2",
+        "gaxios": "^5.0.0",
+        "google-auth-library": "^8.0.1",
         "mime": "^3.0.0",
         "mime-types": "^2.0.8",
         "p-limit": "^3.0.1",
         "pumpify": "^2.0.0",
-        "retry-request": "^4.2.2",
+        "retry-request": "^5.0.0",
         "stream-events": "^1.0.4",
-        "teeny-request": "^7.1.3",
-        "uuid": "^8.0.0",
-        "xdg-basedir": "^4.0.0"
+        "teeny-request": "^8.0.0",
+        "uuid": "^8.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.5.tgz",
-      "integrity": "sha512-A6cOzSu7dqXZ7rzvh/9JZf+Jg/MOpLEMP0IdT8pT8hrWJZ6TB4ydN/MRuqOtAugInJe/VQ9F8BPricUpYZSaZA==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+      "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
       "optional": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.6.4",
@@ -261,16 +197,16 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.7.tgz",
-      "integrity": "sha512-QzTPIyJxU0u+r2qGe8VMl3j/W2ryhEvBv7hc42OjYfthSj370fUrb7na65rG6w3YLZS/fb8p89iTBobfWGDgdw==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
       "optional": true,
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
-        "yargs": "^16.1.1"
+        "protobufjs": "^6.11.3",
+        "yargs": "^16.2.0"
       },
       "bin": {
         "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
@@ -290,7 +226,7 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
       "optional": true
     },
     "node_modules/@protobufjs/base64": {
@@ -308,13 +244,13 @@
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
       "optional": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
@@ -324,31 +260,31 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "optional": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "optional": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
       "optional": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
       "optional": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "optional": true
     },
     "node_modules/@tootallnate/once": {
@@ -420,9 +356,9 @@
       }
     },
     "node_modules/@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "optional": true
     },
     "node_modules/@types/mime": {
@@ -431,14 +367,15 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "node_modules/@types/node": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
-      "integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw=="
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
+      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw=="
     },
     "node_modules/@types/oauth": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
       "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -475,12 +412,12 @@
       }
     },
     "node_modules/accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dependencies": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       },
       "engines": {
         "node": ">= 0.6"
@@ -499,9 +436,9 @@
       }
     },
     "node_modules/agent-base/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "optional": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -598,23 +535,26 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
-      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
       "dependencies": {
-        "bytes": "3.1.1",
+        "bytes": "3.1.2",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.8.1",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.9.6",
-        "raw-body": "2.4.2",
-        "type-is": "~1.6.18"
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -623,11 +563,23 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/bytes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/cliui": {
@@ -671,23 +623,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/configstore": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-      "optional": true,
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -708,9 +643,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -732,15 +667,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -750,39 +676,20 @@
       }
     },
     "node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "node_modules/dicer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.1.tgz",
-      "integrity": "sha512-ObioMtXnmjYs3aRtpIJt9rgQSPCIhKVkFPip+E9GUDyWl8N435znUxK/JfNwGZJ2wnn5JKQ7Ly3vOK5Q5dylGA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/dot-prop": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "optional": true,
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/duplexify": {
@@ -808,7 +715,7 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -819,7 +726,7 @@
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -851,12 +758,12 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -871,37 +778,38 @@
       }
     },
     "node_modules/express": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
-      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
       "dependencies": {
-        "accepts": "~1.3.7",
+        "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.19.1",
+        "body-parser": "1.20.0",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.4.1",
+        "cookie": "0.5.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
+        "finalhandler": "1.2.0",
         "fresh": "0.5.2",
+        "http-errors": "2.0.0",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.9.6",
+        "qs": "6.10.3",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.17.2",
-        "serve-static": "1.14.2",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
         "setprototypeof": "1.2.0",
-        "statuses": "~1.5.0",
+        "statuses": "2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -923,9 +831,9 @@
       "optional": true
     },
     "node_modules/fast-text-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.4.tgz",
+      "integrity": "sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ==",
       "optional": true
     },
     "node_modules/faye-websocket": {
@@ -940,16 +848,16 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
+        "statuses": "2.0.1",
         "unpipe": "~1.0.0"
       },
       "engines": {
@@ -957,39 +865,31 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.2.0.tgz",
-      "integrity": "sha512-6ehn5J9UEFgi4+naqYvozmGpnZae3cJLdwSkSsDc8/Y0eTBjVMFdf9N2ft7N81UNHA0N5DknOyXhlsdAdyBLCA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.0.0.tgz",
+      "integrity": "sha512-x56u+Q1P8QDvQKaYRe29ZUM/3f829cP8tsKCDXOhaIX/GbGfgcdjRhPmCafzlwgCWP5wW9NkOgIhnrw94zucvw==",
       "dependencies": {
-        "@firebase/database-compat": "^0.1.8",
+        "@fastify/busboy": "^1.1.0",
+        "@firebase/database-compat": "^0.2.0",
         "@firebase/database-types": "^0.9.7",
         "@types/node": ">=12.12.47",
-        "dicer": "^0.3.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.2",
         "node-forge": "^1.3.1",
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">=12.7.0"
+        "node": ">=14"
       },
       "optionalDependencies": {
-        "@google-cloud/firestore": "^4.15.1",
-        "@google-cloud/storage": "^5.18.3"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-      "engines": {
-        "node": ">= 6.13.0"
+        "@google-cloud/firestore": "^5.0.2",
+        "@google-cloud/storage": "^6.1.0"
       }
     },
     "node_modules/firebase-functions": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.21.2.tgz",
-      "integrity": "sha512-XZOSv7mLnd8uIzNA+rc+n+oM/g2Nn4rtUkOKeTMccYiWOMdMMUwhzuqRnE28mB65bveU12aTHkaJY6p3Pk6MUw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.22.0.tgz",
+      "integrity": "sha512-d1BxBpT95MhvVqXkpLWDvWbyuX7e2l69cFAiqG3U1XQDaMV88bM9S+Zg7H8i9pitEGFr+76ErjKgrY0n+g3ZDA==",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
@@ -1005,7 +905,7 @@
         "node": "^8.13.0 || >=10.10.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0"
+        "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/forwarded": {
@@ -1019,34 +919,153 @@
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "engines": {
         "node": ">= 0.6"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "optional": true
     },
     "node_modules/gaxios": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.2.tgz",
-      "integrity": "sha512-T+ap6GM6UZ0c4E6yb1y/hy2UB6hTrqhglp3XfmU9qbLCGRYhLVV5aRPpC4EmoG8N8zOnkYCgoBz+ScvGAARY6Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.1.tgz",
+      "integrity": "sha512-keK47BGKHyyOVQxgcUaSaFvr3ehZYAlvhvpHXy0YB2itzZef+GqZR8TBsfVRWghdwlKrYsn+8L8i3eblF7Oviw==",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
+      "integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "optional": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.1.1.tgz",
+      "integrity": "sha512-eG3pCfrLgVJe19KhAeZwW0m1LplNEo0FX1GboWf3hu18zD2jq8TUH2K8900AB2YRAuJ7A+1aSXDp1BODjwwRzg==",
+      "optional": true,
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.0.0",
+        "gtoken": "^6.0.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "2.30.5",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.30.5.tgz",
+      "integrity": "sha512-Jey13YrAN2hfpozHzbtrwEfEHdStJh1GwaQ2+Akh1k0Tv/EuNVSuBtHZoKSBm5wBMvNsxTsEIZ/152NrYyZgxQ==",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "~1.6.0",
+        "@grpc/proto-loader": "^0.6.12",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "fast-text-encoding": "^1.0.3",
+        "google-auth-library": "^7.14.0",
+        "is-stream-ended": "^0.1.4",
+        "node-fetch": "^2.6.1",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^0.1.8",
+        "protobufjs": "6.11.3",
+        "retry-request": "^4.0.0"
+      },
+      "bin": {
+        "compileProtos": "build/tools/compileProtos.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/google-gax/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "optional": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/google-gax/node_modules/gaxios": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
       "optional": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.1"
+        "node-fetch": "^2.6.7"
       },
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/gcp-metadata": {
+    "node_modules/google-gax/node_modules/gcp-metadata": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
       "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
@@ -1059,16 +1078,7 @@
         "node": ">=10"
       }
     },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "optional": true,
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/google-auth-library": {
+    "node_modules/google-gax/node_modules/google-auth-library": {
       "version": "7.14.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
       "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
@@ -1088,40 +1098,13 @@
         "node": ">=10"
       }
     },
-    "node_modules/google-gax": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.28.1.tgz",
-      "integrity": "sha512-2Xjd3FrjlVd6Cmw2B2Aicpc/q92SwTpIOvxPUlnRg9w+Do8nu7UR+eQrgoKlo2FIUcUuDTvppvcx8toND0pK9g==",
+    "node_modules/google-gax/node_modules/google-p12-pem": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
+      "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
       "optional": true,
       "dependencies": {
-        "@grpc/grpc-js": "~1.4.0",
-        "@grpc/proto-loader": "^0.6.1",
-        "@types/long": "^4.0.0",
-        "abort-controller": "^3.0.0",
-        "duplexify": "^4.0.0",
-        "fast-text-encoding": "^1.0.3",
-        "google-auth-library": "^7.6.1",
-        "is-stream-ended": "^0.1.4",
-        "node-fetch": "^2.6.1",
-        "object-hash": "^2.1.1",
-        "proto3-json-serializer": "^0.1.5",
-        "protobufjs": "6.11.2",
-        "retry-request": "^4.0.0"
-      },
-      "bin": {
-        "compileProtos": "build/tools/compileProtos.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/google-p12-pem": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.2.tgz",
-      "integrity": "sha512-tjf3IQIt7tWCDsa0ofDQ1qqSCNzahXDxdAGJDbruWqu3eCg5CKLYKN+hi0s6lfvzYZ1GDVr+oDF9OOWlDSdf0A==",
-      "optional": true,
-      "dependencies": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.3.1"
       },
       "bin": {
         "gp12-pem": "build/src/bin/gp12-pem.js"
@@ -1130,51 +1113,125 @@
         "node": ">=10"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "optional": true
-    },
-    "node_modules/gtoken": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.1.tgz",
-      "integrity": "sha512-yqOREjzLHcbzz1UrQoxhBtpk8KjrVhuqPE7od1K2uhyxG2BHjKZetlbLw/SPZak/QqTIQW+addS+EcjqQsZbwQ==",
+    "node_modules/google-gax/node_modules/gtoken": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
+      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
       "optional": true,
       "dependencies": {
         "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.0.3",
+        "google-p12-pem": "^3.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/hash-stream-validation": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz",
-      "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ==",
+    "node_modules/google-gax/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "optional": true
     },
-    "node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+    "node_modules/google-gax/node_modules/retry-request": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
+      "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+      "optional": true,
       "dependencies": {
-        "depd": "~1.1.2",
+        "debug": "^4.1.1",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/google-p12-pem": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.0.tgz",
+      "integrity": "sha512-lRTMn5ElBdDixv4a86bixejPSRk1boRtUowNepeKEVvYiFlkLuAJUVpEz6PfObDHYEKnZWq/9a2zC98xu62A9w==",
+      "optional": true,
+      "dependencies": {
+        "node-forge": "^1.3.1"
+      },
+      "bin": {
+        "gp12-pem": "build/src/bin/gp12-pem.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.0.tgz",
+      "integrity": "sha512-WPZcFw34wh2LUvbCUWI70GDhOlO7qHpSvFHFqq7d3Wvsf8dIJedE0lnUdOmsKuC0NgflKmF0LxIF38vsGeHHiQ==",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^4.0.0",
+        "google-p12-pem": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/gaxios": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+      "optional": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/http-parser-js": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.6.tgz",
-      "integrity": "sha512-vDlkRPDJn93swjcjqMSaGSPABbIarsr1TLAui/gLDXzV5VsJNdXNzMYDyNBLQkjWQCJ1uizu8T2oDMhmGt0PRA=="
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -1214,9 +1271,9 @@
       "optional": true
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "optional": true,
       "dependencies": {
         "agent-base": "6",
@@ -1227,9 +1284,9 @@
       }
     },
     "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "optional": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -1260,21 +1317,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/idb": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
-      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg==",
-      "peer": true
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1297,15 +1339,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -1322,12 +1355,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
       "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
-      "optional": true
-    },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "optional": true
     },
     "node_modules/jose": {
@@ -1468,7 +1495,7 @@
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "optional": true
     },
     "node_modules/lodash.clonedeep": {
@@ -1552,34 +1579,10 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "optional": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1631,12 +1634,12 @@
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1661,12 +1664,11 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "optional": true,
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/oauth": {
@@ -1683,18 +1685,26 @@
       }
     },
     "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "optional": true,
       "engines": {
         "node": ">= 6"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -1705,7 +1715,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "optional": true,
       "dependencies": {
         "wrappy": "1"
@@ -1740,18 +1750,18 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "node_modules/proto3-json-serializer": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.6.tgz",
-      "integrity": "sha512-tGbV6m6Kad8NqxMh5hw87euPS0YoZSAOIfvR01zYkQV8Gpx1V/8yU/0gCKCvfCkhAJsjvzzhnnsdQxA1w7PSog==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz",
+      "integrity": "sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==",
       "optional": true,
       "dependencies": {
         "protobufjs": "^6.11.2"
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -1813,9 +1823,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
         "node": ">=0.6"
       },
@@ -1832,12 +1845,12 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
-      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "dependencies": {
-        "bytes": "3.1.1",
-        "http-errors": "1.8.1",
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
@@ -1862,7 +1875,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1878,22 +1891,22 @@
       }
     },
     "node_modules/retry-request": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
-      "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.1.tgz",
+      "integrity": "sha512-lxFKrlBt0OZzCWh/V0uPEN0vlr3OhdeXnpeY5OES+ckslm791Cb1D5P7lJUSnY7J5hiCjcyaUGmzCnIGDCUBig==",
       "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "extend": "^3.0.2"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=12"
       }
     },
     "node_modules/retry-request/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "optional": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -1946,23 +1959,23 @@
       }
     },
     "node_modules/send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
       "dependencies": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.8.1",
+        "http-errors": "2.0.0",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
+        "statuses": "2.0.1"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -1985,14 +1998,14 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/serve-static": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.17.2"
+        "send": "0.18.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -2003,18 +2016,25 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "optional": true
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/stream-events": {
@@ -2031,14 +2051,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "optional": true
-    },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -2078,13 +2090,13 @@
     "node_modules/stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
       "optional": true
     },
     "node_modules/teeny-request": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.2.0.tgz",
-      "integrity": "sha512-SyY0pek1zWsi0LRVAALem+avzMLc33MKW/JLLakdP4s9+D7+jHcy5x6P+h94g2QNZsAqQNfX5lsbd3WSeJXrrw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.0.tgz",
+      "integrity": "sha512-6KEYxXI4lQPSDkXzXpPmJPNmo7oqduFFbhOEHf8sfsLbXyCsb+umUjBtMGAKhaSToD8JNCtQutTRefu29K64JA==",
       "optional": true,
       "dependencies": {
         "http-proxy-agent": "^5.0.0",
@@ -2094,8 +2106,13 @@
         "uuid": "^8.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
+    },
+    "node_modules/text-decoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
+      "integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -2127,15 +2144,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "optional": true,
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "node_modules/typescript": {
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
@@ -2149,22 +2157,10 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "optional": true,
-      "dependencies": {
-        "crypto-random-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2172,7 +2168,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "optional": true
     },
     "node_modules/utils-merge": {
@@ -2254,29 +2250,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "optional": true
-    },
-    "node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "optional": true,
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "node_modules/xdg-basedir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -2334,30 +2309,12 @@
     }
   },
   "dependencies": {
-    "@firebase/app": {
-      "version": "0.7.25",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.25.tgz",
-      "integrity": "sha512-OemDA3NZS1oEbAPFlWHeVI8Od26ZHAXUivUWFYIsYrw+YjS7FloltwyHB06Q8LQyPJIBPubGkEuzNTHz32EDCQ==",
-      "peer": true,
+    "@fastify/busboy": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-1.1.0.tgz",
+      "integrity": "sha512-Fv854f94v0CzIDllbY3i/0NJPNBRNLDawf3BTYVGCe9VrIIs3Wi7AFx24F9NzCxdf0wyx/x0Q9kEVnvDOPnlxA==",
       "requires": {
-        "@firebase/component": "0.5.14",
-        "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.6.0",
-        "idb": "7.0.1",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@firebase/app-compat": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.26.tgz",
-      "integrity": "sha512-i5UTq1HZAHuhe7RNjgFSezbow4jVxc2oe3Gndsv+Hdut92f8L0AyssOtdU2iOylLlxbTijewAXXui4FAUzXubw==",
-      "peer": true,
-      "requires": {
-        "@firebase/app": "0.7.25",
-        "@firebase/component": "0.5.14",
-        "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.6.0",
-        "tslib": "^2.1.0"
+        "text-decoding": "^1.0.0"
       }
     },
     "@firebase/app-types": {
@@ -2372,117 +2329,69 @@
       "requires": {}
     },
     "@firebase/component": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.14.tgz",
-      "integrity": "sha512-ct2p1MTMV5P/nGIlkC3XjAVwHwjsIZaeo8JVyDAkJCNTROu5mYX3FBK16hjIUIIVJDpgnnzFh9nP74gciL4WrA==",
-      "peer": true,
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.17.tgz",
+      "integrity": "sha512-mTM5CBSIlmI+i76qU4+DhuExnWtzcPS3cVgObA3VAjliPPr3GrUlTaaa8KBGfxsD27juQxMsYA0TvCR5X+GQ3Q==",
       "requires": {
-        "@firebase/util": "1.6.0",
+        "@firebase/util": "1.6.3",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database": {
-      "version": "0.12.8",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.12.8.tgz",
-      "integrity": "sha512-JBQVfFLzfhxlQbl4OU6ov9fdsddkytBQdtSSR49cz48homj38ccltAhK6seum+BI7f28cV2LFHF9672lcN+qxA==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.13.3.tgz",
+      "integrity": "sha512-ZE+QJqQUaCTZiIzGq3RJLo64HRMtbdaEwyDhfZyPEzMJV4kyLsw3cHdEHVCtBmdasTvwtpO2YRFmd4AXAoKtNw==",
       "requires": {
         "@firebase/auth-interop-types": "0.1.6",
-        "@firebase/component": "0.5.13",
-        "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.5.2",
+        "@firebase/component": "0.5.17",
+        "@firebase/logger": "0.3.3",
+        "@firebase/util": "1.6.3",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@firebase/component": {
-          "version": "0.5.13",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.13.tgz",
-          "integrity": "sha512-hxhJtpD8Ppf/VU2Rlos6KFCEV77TGIGD5bJlkPK1+B/WUe0mC6dTjW7KhZtXTc+qRBp9nFHWcsIORnT8liHP9w==",
-          "requires": {
-            "@firebase/util": "1.5.2",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.5.2.tgz",
-          "integrity": "sha512-YvBH2UxFcdWG2HdFnhxZptPl2eVFlpOyTH66iDo13JPEYraWzWToZ5AMTtkyRHVmu7sssUpQlU9igy1KET7TOw==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
       }
     },
     "@firebase/database-compat": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.1.8.tgz",
-      "integrity": "sha512-dhXr5CSieBuKNdU96HgeewMQCT9EgOIkfF1GNy+iRrdl7BWLxmlKuvLfK319rmIytSs/vnCzcD9uqyxTeU/A3A==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.2.3.tgz",
+      "integrity": "sha512-uwSMnbjlSQM5gQRq8OoBLs7uc7obwsl0D6kSDAnMOlPtPl9ert79Rq9faU/COjybsJ8l7tNXMVYYJo3mQ5XNrA==",
       "requires": {
-        "@firebase/component": "0.5.13",
-        "@firebase/database": "0.12.8",
-        "@firebase/database-types": "0.9.7",
-        "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.5.2",
+        "@firebase/component": "0.5.17",
+        "@firebase/database": "0.13.3",
+        "@firebase/database-types": "0.9.11",
+        "@firebase/logger": "0.3.3",
+        "@firebase/util": "1.6.3",
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@firebase/component": {
-          "version": "0.5.13",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.13.tgz",
-          "integrity": "sha512-hxhJtpD8Ppf/VU2Rlos6KFCEV77TGIGD5bJlkPK1+B/WUe0mC6dTjW7KhZtXTc+qRBp9nFHWcsIORnT8liHP9w==",
-          "requires": {
-            "@firebase/util": "1.5.2",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/database-types": {
-          "version": "0.9.7",
-          "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.7.tgz",
-          "integrity": "sha512-EFhgL89Fz6DY3kkB8TzdHvdu8XaqqvzcF2DLVOXEnQ3Ms7L755p5EO42LfxXoJqb9jKFvgLpFmKicyJG25WFWw==",
-          "requires": {
-            "@firebase/app-types": "0.7.0",
-            "@firebase/util": "1.5.2"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.5.2.tgz",
-          "integrity": "sha512-YvBH2UxFcdWG2HdFnhxZptPl2eVFlpOyTH66iDo13JPEYraWzWToZ5AMTtkyRHVmu7sssUpQlU9igy1KET7TOw==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
       }
     },
     "@firebase/database-types": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.8.tgz",
-      "integrity": "sha512-bI7bwF5xc0nPi6Oa3JVt6JJdfhVAnEpCwgfTNILR4lYDPtxdxlRXhZzQ5lfqlCj7PR+drKh9RvMu6C24N1q04w==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.11.tgz",
+      "integrity": "sha512-27V3eFomWCZqLR6qb3Q9eS2lsUtulhSHeDNaL6fImwnhvMYTmf6ZwMfRWupgi8AFwW4s91g9Oc1/fkQtJGHKQw==",
       "requires": {
         "@firebase/app-types": "0.7.0",
-        "@firebase/util": "1.6.0"
+        "@firebase/util": "1.6.3"
       }
     },
     "@firebase/logger": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.2.tgz",
-      "integrity": "sha512-lzLrcJp9QBWpo40OcOM9B8QEtBw2Fk1zOZQdvv+rWS6gKmhQBCEMc4SMABQfWdjsylBcDfniD1Q+fUX1dcBTXA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.3.tgz",
+      "integrity": "sha512-POTJl07jOKTOevLXrTvJD/VZ0M6PnJXflbAh5J9VGkmtXPXNG6MdZ9fmRgqYhXKTaDId6AQenQ262uwgpdtO0Q==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@firebase/util": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.6.0.tgz",
-      "integrity": "sha512-6+hhqb4Zzjoo12xofTDHPkgW3FnN4ydBsjd5X2KuQI268DR3W3Ld64W/gkKPZrKRgUxeNeb+pykfP3qRe7q+vA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.6.3.tgz",
+      "integrity": "sha512-FujteO6Zjv6v8A4HS+t7c+PjU0Kaxj+rOnka0BsI/twUaCC9t8EQPmXpWZdk7XfszfahJn2pqsflUWUhtUkRlg==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@google-cloud/firestore": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-4.15.1.tgz",
-      "integrity": "sha512-2PWsCkEF1W02QbghSeRsNdYKN1qavrHBP3m72gPDMHQSYrGULOaTi7fSJquQmAtc4iPVB2/x6h80rdLHTATQtA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-5.0.2.tgz",
+      "integrity": "sha512-xlGcNYaW0nvUMzNn2+pLfbEBVt6oysVqtM89faMgZWkWfEtvIQGS0h5PRdLlcqufNzRCX3yIGv29Pb+03ys+VA==",
       "optional": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -2502,52 +2411,49 @@
       }
     },
     "@google-cloud/projectify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.1.tgz",
-      "integrity": "sha512-+rssMZHnlh0twl122gXY4/aCrk0G1acBqkHFfYddtsqpYXGxA29nj9V5V9SfC+GyOG00l650f6lG9KL+EpFEWQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
+      "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
       "optional": true
     },
     "@google-cloud/promisify": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz",
-      "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.0.tgz",
+      "integrity": "sha512-91ArYvRgXWb73YvEOBMmOcJc0bDRs5yiVHnqkwoG0f3nm7nZuipllz6e7BvFESBvjkDTBC0zMD8QxedUwNLc1A==",
       "optional": true
     },
     "@google-cloud/storage": {
-      "version": "5.20.5",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.20.5.tgz",
-      "integrity": "sha512-lOs/dCyveVF8TkVFnFSF7IGd0CJrTm91qiK6JLu+Z8qiT+7Ag0RyVhxZIWkhiACqwABo7kSHDm8FdH8p2wxSSw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.2.3.tgz",
+      "integrity": "sha512-UJqn3Ln8wFBPLuwBaNu3PlhzQDL3EKKfP1+3mzLRQhcFqgpBSMPLDgAXxc6e9S0l0kqsi4GOuAA7fA+l/VAMjQ==",
       "optional": true,
       "requires": {
         "@google-cloud/paginator": "^3.0.7",
-        "@google-cloud/projectify": "^2.0.0",
-        "@google-cloud/promisify": "^2.0.0",
+        "@google-cloud/projectify": "^3.0.0",
+        "@google-cloud/promisify": "^3.0.0",
         "abort-controller": "^3.0.0",
         "arrify": "^2.0.0",
         "async-retry": "^1.3.3",
         "compressible": "^2.0.12",
-        "configstore": "^5.0.0",
         "duplexify": "^4.0.0",
         "ent": "^2.2.0",
         "extend": "^3.0.2",
-        "gaxios": "^4.0.0",
-        "google-auth-library": "^7.14.1",
-        "hash-stream-validation": "^0.2.2",
+        "gaxios": "^5.0.0",
+        "google-auth-library": "^8.0.1",
         "mime": "^3.0.0",
         "mime-types": "^2.0.8",
         "p-limit": "^3.0.1",
         "pumpify": "^2.0.0",
-        "retry-request": "^4.2.2",
+        "retry-request": "^5.0.0",
         "stream-events": "^1.0.4",
-        "teeny-request": "^7.1.3",
-        "uuid": "^8.0.0",
-        "xdg-basedir": "^4.0.0"
+        "teeny-request": "^8.0.0",
+        "uuid": "^8.0.0"
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.5.tgz",
-      "integrity": "sha512-A6cOzSu7dqXZ7rzvh/9JZf+Jg/MOpLEMP0IdT8pT8hrWJZ6TB4ydN/MRuqOtAugInJe/VQ9F8BPricUpYZSaZA==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+      "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
       "optional": true,
       "requires": {
         "@grpc/proto-loader": "^0.6.4",
@@ -2555,16 +2461,16 @@
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.7.tgz",
-      "integrity": "sha512-QzTPIyJxU0u+r2qGe8VMl3j/W2ryhEvBv7hc42OjYfthSj370fUrb7na65rG6w3YLZS/fb8p89iTBobfWGDgdw==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
       "optional": true,
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
-        "yargs": "^16.1.1"
+        "protobufjs": "^6.11.3",
+        "yargs": "^16.2.0"
       }
     },
     "@panva/asn1.js": {
@@ -2575,7 +2481,7 @@
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
       "optional": true
     },
     "@protobufjs/base64": {
@@ -2593,13 +2499,13 @@
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
       "optional": true
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "optional": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
@@ -2609,31 +2515,31 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "optional": true
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "optional": true
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
       "optional": true
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
       "optional": true
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "optional": true
     },
     "@tootallnate/once": {
@@ -2702,9 +2608,9 @@
       }
     },
     "@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "optional": true
     },
     "@types/mime": {
@@ -2713,14 +2619,15 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "@types/node": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
-      "integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw=="
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
+      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw=="
     },
     "@types/oauth": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
       "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -2754,12 +2661,12 @@
       }
     },
     "accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "requires": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       }
     },
     "agent-base": {
@@ -2772,9 +2679,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "optional": true,
           "requires": {
             "ms": "2.1.2"
@@ -2836,20 +2743,22 @@
       "optional": true
     },
     "body-parser": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
-      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
       "requires": {
-        "bytes": "3.1.1",
+        "bytes": "3.1.2",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.8.1",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.9.6",
-        "raw-body": "2.4.2",
-        "type-is": "~1.6.18"
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
       }
     },
     "buffer-equal-constant-time": {
@@ -2858,9 +2767,18 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "bytes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
     },
     "cliui": {
       "version": "7.0.4",
@@ -2897,20 +2815,6 @@
         "mime-db": ">= 1.43.0 < 2"
       }
     },
-    "configstore": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-      "optional": true,
-      "requires": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
-      }
-    },
     "content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -2925,9 +2829,9 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -2943,12 +2847,6 @@
         "vary": "^1"
       }
     },
-    "crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "optional": true
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2958,31 +2856,14 @@
       }
     },
     "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
     "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "dicer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.1.tgz",
-      "integrity": "sha512-ObioMtXnmjYs3aRtpIJt9rgQSPCIhKVkFPip+E9GUDyWl8N435znUxK/JfNwGZJ2wnn5JKQ7Ly3vOK5Q5dylGA==",
-      "requires": {
-        "streamsearch": "^1.1.0"
-      }
-    },
-    "dot-prop": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "optional": true,
-      "requires": {
-        "is-obj": "^2.0.0"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
     "duplexify": {
       "version": "4.1.2",
@@ -3007,7 +2888,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -3018,7 +2899,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3044,12 +2925,12 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
     "event-target-shim": {
       "version": "5.0.1",
@@ -3058,37 +2939,38 @@
       "optional": true
     },
     "express": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
-      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
       "requires": {
-        "accepts": "~1.3.7",
+        "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.19.1",
+        "body-parser": "1.20.0",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.4.1",
+        "cookie": "0.5.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
+        "finalhandler": "1.2.0",
         "fresh": "0.5.2",
+        "http-errors": "2.0.0",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.9.6",
+        "qs": "6.10.3",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.17.2",
-        "serve-static": "1.14.2",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
         "setprototypeof": "1.2.0",
-        "statuses": "~1.5.0",
+        "statuses": "2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -3107,9 +2989,9 @@
       "optional": true
     },
     "fast-text-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.4.tgz",
+      "integrity": "sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ==",
       "optional": true
     },
     "faye-websocket": {
@@ -3121,47 +3003,40 @@
       }
     },
     "finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
+        "statuses": "2.0.1",
         "unpipe": "~1.0.0"
       }
     },
     "firebase-admin": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.2.0.tgz",
-      "integrity": "sha512-6ehn5J9UEFgi4+naqYvozmGpnZae3cJLdwSkSsDc8/Y0eTBjVMFdf9N2ft7N81UNHA0N5DknOyXhlsdAdyBLCA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.0.0.tgz",
+      "integrity": "sha512-x56u+Q1P8QDvQKaYRe29ZUM/3f829cP8tsKCDXOhaIX/GbGfgcdjRhPmCafzlwgCWP5wW9NkOgIhnrw94zucvw==",
       "requires": {
-        "@firebase/database-compat": "^0.1.8",
+        "@fastify/busboy": "^1.1.0",
+        "@firebase/database-compat": "^0.2.0",
         "@firebase/database-types": "^0.9.7",
-        "@google-cloud/firestore": "^4.15.1",
-        "@google-cloud/storage": "^5.18.3",
+        "@google-cloud/firestore": "^5.0.2",
+        "@google-cloud/storage": "^6.1.0",
         "@types/node": ">=12.12.47",
-        "dicer": "^0.3.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.2",
         "node-forge": "^1.3.1",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-          "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
-        }
       }
     },
     "firebase-functions": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.21.2.tgz",
-      "integrity": "sha512-XZOSv7mLnd8uIzNA+rc+n+oM/g2Nn4rtUkOKeTMccYiWOMdMMUwhzuqRnE28mB65bveU12aTHkaJY6p3Pk6MUw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.22.0.tgz",
+      "integrity": "sha512-d1BxBpT95MhvVqXkpLWDvWbyuX7e2l69cFAiqG3U1XQDaMV88bM9S+Zg7H8i9pitEGFr+76ErjKgrY0n+g3ZDA==",
       "requires": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
@@ -3179,34 +3054,38 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "optional": true
     },
     "gaxios": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.2.tgz",
-      "integrity": "sha512-T+ap6GM6UZ0c4E6yb1y/hy2UB6hTrqhglp3XfmU9qbLCGRYhLVV5aRPpC4EmoG8N8zOnkYCgoBz+ScvGAARY6Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.1.tgz",
+      "integrity": "sha512-keK47BGKHyyOVQxgcUaSaFvr3ehZYAlvhvpHXy0YB2itzZef+GqZR8TBsfVRWghdwlKrYsn+8L8i3eblF7Oviw==",
       "optional": true,
       "requires": {
-        "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.1"
+        "node-fetch": "^2.6.7"
       }
     },
     "gcp-metadata": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
-      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
+      "integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
       "optional": true,
       "requires": {
-        "gaxios": "^4.0.0",
+        "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
       }
     },
@@ -3216,92 +3095,205 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "optional": true
     },
+    "get-intrinsic": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
+    },
     "google-auth-library": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
-      "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.1.1.tgz",
+      "integrity": "sha512-eG3pCfrLgVJe19KhAeZwW0m1LplNEo0FX1GboWf3hu18zD2jq8TUH2K8900AB2YRAuJ7A+1aSXDp1BODjwwRzg==",
       "optional": true,
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.0.0",
+        "gtoken": "^6.0.0",
         "jws": "^4.0.0",
         "lru-cache": "^6.0.0"
       }
     },
     "google-gax": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.28.1.tgz",
-      "integrity": "sha512-2Xjd3FrjlVd6Cmw2B2Aicpc/q92SwTpIOvxPUlnRg9w+Do8nu7UR+eQrgoKlo2FIUcUuDTvppvcx8toND0pK9g==",
+      "version": "2.30.5",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.30.5.tgz",
+      "integrity": "sha512-Jey13YrAN2hfpozHzbtrwEfEHdStJh1GwaQ2+Akh1k0Tv/EuNVSuBtHZoKSBm5wBMvNsxTsEIZ/152NrYyZgxQ==",
       "optional": true,
       "requires": {
-        "@grpc/grpc-js": "~1.4.0",
-        "@grpc/proto-loader": "^0.6.1",
+        "@grpc/grpc-js": "~1.6.0",
+        "@grpc/proto-loader": "^0.6.12",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "fast-text-encoding": "^1.0.3",
-        "google-auth-library": "^7.6.1",
+        "google-auth-library": "^7.14.0",
         "is-stream-ended": "^0.1.4",
         "node-fetch": "^2.6.1",
-        "object-hash": "^2.1.1",
-        "proto3-json-serializer": "^0.1.5",
-        "protobufjs": "6.11.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^0.1.8",
+        "protobufjs": "6.11.3",
         "retry-request": "^4.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "optional": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "gaxios": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+          "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+          "optional": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.7"
+          }
+        },
+        "gcp-metadata": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+          "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+          "optional": true,
+          "requires": {
+            "gaxios": "^4.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "7.14.1",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
+          "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+          "optional": true,
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
+          "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
+          "optional": true,
+          "requires": {
+            "node-forge": "^1.3.1"
+          }
+        },
+        "gtoken": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
+          "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
+          "optional": true,
+          "requires": {
+            "gaxios": "^4.0.0",
+            "google-p12-pem": "^3.1.3",
+            "jws": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "optional": true
+        },
+        "retry-request": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
+          "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+          "optional": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "extend": "^3.0.2"
+          }
+        }
       }
     },
     "google-p12-pem": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.2.tgz",
-      "integrity": "sha512-tjf3IQIt7tWCDsa0ofDQ1qqSCNzahXDxdAGJDbruWqu3eCg5CKLYKN+hi0s6lfvzYZ1GDVr+oDF9OOWlDSdf0A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.0.tgz",
+      "integrity": "sha512-lRTMn5ElBdDixv4a86bixejPSRk1boRtUowNepeKEVvYiFlkLuAJUVpEz6PfObDHYEKnZWq/9a2zC98xu62A9w==",
       "optional": true,
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.3.1"
       }
     },
-    "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "optional": true
-    },
     "gtoken": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.1.tgz",
-      "integrity": "sha512-yqOREjzLHcbzz1UrQoxhBtpk8KjrVhuqPE7od1K2uhyxG2BHjKZetlbLw/SPZak/QqTIQW+addS+EcjqQsZbwQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.0.tgz",
+      "integrity": "sha512-WPZcFw34wh2LUvbCUWI70GDhOlO7qHpSvFHFqq7d3Wvsf8dIJedE0lnUdOmsKuC0NgflKmF0LxIF38vsGeHHiQ==",
       "optional": true,
       "requires": {
         "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.0.3",
+        "google-p12-pem": "^4.0.0",
         "jws": "^4.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+          "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+          "optional": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.7"
+          }
+        }
       }
     },
-    "hash-stream-validation": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz",
-      "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ==",
-      "optional": true
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
       }
     },
     "http-parser-js": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.6.tgz",
-      "integrity": "sha512-vDlkRPDJn93swjcjqMSaGSPABbIarsr1TLAui/gLDXzV5VsJNdXNzMYDyNBLQkjWQCJ1uizu8T2oDMhmGt0PRA=="
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
     },
     "http-proxy-agent": {
       "version": "5.0.0",
@@ -3332,9 +3324,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "optional": true,
       "requires": {
         "agent-base": "6",
@@ -3342,9 +3334,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "optional": true,
           "requires": {
             "ms": "2.1.2"
@@ -3366,18 +3358,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "idb": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
-      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg==",
-      "peer": true
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "optional": true
-    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3394,12 +3374,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "optional": true
     },
-    "is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "optional": true
-    },
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3410,12 +3384,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
       "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
-      "optional": true
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "optional": true
     },
     "jose": {
@@ -3539,7 +3507,7 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "optional": true
     },
     "lodash.clonedeep": {
@@ -3622,27 +3590,10 @@
         }
       }
     },
-    "make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "optional": true,
-      "requires": {
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "optional": true
-        }
-      }
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -3676,12 +3627,12 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -3692,10 +3643,9 @@
       }
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "optional": true
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "oauth": {
       "version": "0.9.15",
@@ -3708,15 +3658,20 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "optional": true
     },
+    "object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+    },
     "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -3724,7 +3679,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "optional": true,
       "requires": {
         "wrappy": "1"
@@ -3750,18 +3705,18 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "proto3-json-serializer": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.6.tgz",
-      "integrity": "sha512-tGbV6m6Kad8NqxMh5hw87euPS0YoZSAOIfvR01zYkQV8Gpx1V/8yU/0gCKCvfCkhAJsjvzzhnnsdQxA1w7PSog==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz",
+      "integrity": "sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==",
       "optional": true,
       "requires": {
         "protobufjs": "^6.11.2"
       }
     },
     "protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "optional": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -3815,9 +3770,12 @@
       }
     },
     "qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "range-parser": {
       "version": "1.2.1",
@@ -3825,12 +3783,12 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
-      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "requires": {
-        "bytes": "3.1.1",
-        "http-errors": "1.8.1",
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       }
@@ -3849,7 +3807,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "optional": true
     },
     "retry": {
@@ -3859,9 +3817,9 @@
       "optional": true
     },
     "retry-request": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
-      "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.1.tgz",
+      "integrity": "sha512-lxFKrlBt0OZzCWh/V0uPEN0vlr3OhdeXnpeY5OES+ckslm791Cb1D5P7lJUSnY7J5hiCjcyaUGmzCnIGDCUBig==",
       "optional": true,
       "requires": {
         "debug": "^4.1.1",
@@ -3869,9 +3827,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "optional": true,
           "requires": {
             "ms": "2.1.2"
@@ -3901,23 +3859,23 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.8.1",
+        "http-errors": "2.0.0",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
+        "statuses": "2.0.1"
       },
       "dependencies": {
         "mime": {
@@ -3933,14 +3891,14 @@
       }
     },
     "serve-static": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.17.2"
+        "send": "0.18.0"
       }
     },
     "setprototypeof": {
@@ -3948,16 +3906,20 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
-    "signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "optional": true
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
     },
     "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
     "stream-events": {
       "version": "1.0.5",
@@ -3973,11 +3935,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "optional": true
-    },
-    "streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -4011,13 +3968,13 @@
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
       "optional": true
     },
     "teeny-request": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.2.0.tgz",
-      "integrity": "sha512-SyY0pek1zWsi0LRVAALem+avzMLc33MKW/JLLakdP4s9+D7+jHcy5x6P+h94g2QNZsAqQNfX5lsbd3WSeJXrrw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.0.tgz",
+      "integrity": "sha512-6KEYxXI4lQPSDkXzXpPmJPNmo7oqduFFbhOEHf8sfsLbXyCsb+umUjBtMGAKhaSToD8JNCtQutTRefu29K64JA==",
       "optional": true,
       "requires": {
         "http-proxy-agent": "^5.0.0",
@@ -4026,6 +3983,11 @@
         "stream-events": "^1.0.5",
         "uuid": "^8.0.0"
       }
+    },
+    "text-decoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
+      "integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA=="
     },
     "toidentifier": {
       "version": "1.0.1",
@@ -4051,39 +4013,21 @@
         "mime-types": "~2.1.24"
       }
     },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "optional": true,
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "typescript": {
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
       "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "dev": true
     },
-    "unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "optional": true,
-      "requires": {
-        "crypto-random-string": "^2.0.0"
-      }
-    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "optional": true
     },
     "utils-merge": {
@@ -4144,25 +4088,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "optional": true
-    },
-    "write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "optional": true,
-      "requires": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "xdg-basedir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "optional": true
     },
     "y18n": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,10 +17,12 @@
     "express": "^4.18.1",
     "firebase-admin": "^11.0.0",
     "firebase-functions": "^3.22.0",
+    "luxon": "^3.0.1",
     "node-fetch": "^2.6.7",
     "oauth": "^0.9.15"
   },
   "devDependencies": {
+    "@types/luxon": "^3.0.0",
     "@types/node": "^18.0.6",
     "@types/oauth": "^0.9.1",
     "typescript": "^4.7.3"

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,14 +14,15 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@types/node": "^17.0.5",
-    "@types/oauth": "^0.9.1",
-    "firebase-admin": "^10.2.0",
-    "firebase-functions": "^3.21.2",
+    "express": "^4.18.1",
+    "firebase-admin": "^11.0.0",
+    "firebase-functions": "^3.22.0",
     "node-fetch": "^2.6.7",
     "oauth": "^0.9.15"
   },
   "devDependencies": {
+    "@types/node": "^18.0.6",
+    "@types/oauth": "^0.9.1",
     "typescript": "^4.7.3"
   },
   "private": true

--- a/functions/src/api.ts
+++ b/functions/src/api.ts
@@ -1,0 +1,25 @@
+import * as functions from 'firebase-functions';
+import express from 'express';
+import admin from './util/adminInit';
+
+const app = express();
+
+
+async function getAlternates() {
+    const doc = await admin.firestore().collection('gunn').doc('alternates').get();
+    return doc.data();
+}
+
+// GET /api
+app.get('/', (req, res) => {
+    res.send('Hello!');
+});
+
+// GET /api/alternates
+app.get('/alternates', async (req, res) => {
+    const data = await getAlternates();
+    if (!data) return res.status(500).json({error: 'Alternates document malformed or nonexistant.'});
+    return res.json(data);
+})
+
+export const api = functions.https.onRequest(app);

--- a/functions/src/api.ts
+++ b/functions/src/api.ts
@@ -1,6 +1,8 @@
 import * as functions from 'firebase-functions';
 import express from 'express';
 import admin from './util/adminInit';
+import {DateTime} from 'luxon';
+import {getSchedule} from './util/schedule';
 
 const app = express();
 
@@ -10,16 +12,25 @@ async function getAlternates() {
     return doc.data();
 }
 
-// GET /api
-app.get('/', (req, res) => {
-    res.send('Hello!');
-});
-
 // GET /api/alternates
+// Gets WATT's parsed alternate schedules. See https://github.com/GunnWATT/watt/blob/main/client/src/contexts/AlternatesContext.ts#L5-L8
+// for information about this endpoint's return type.
 app.get('/alternates', async (req, res) => {
     const data = await getAlternates();
     if (!data) return res.status(500).json({error: 'Alternates document malformed or nonexistant.'});
     return res.json(data);
-})
+});
+
+// GET /api/schedule
+// Gets the current day's schedule, accounting for alternates. Returns the current schedule as `{periods: PeriodObj[] | null, alternate: boolean}`,
+// with `periods` set to an array of the day's periods (or `null` if there is no school) and `alternate` set to whether
+// the returned schedule is an alternate.
+app.get('/schedule', async (req, res) => {
+    const alternates = await getAlternates();
+    if (!alternates) return res.status(500).json({error: 'Alternates document malformed or nonexistant.'});
+
+    const schedule = getSchedule(DateTime.now(), alternates);
+    return res.json(schedule);
+});
 
 export const api = functions.https.onRequest(app);

--- a/functions/src/api.ts
+++ b/functions/src/api.ts
@@ -17,7 +17,7 @@ async function getAlternates() {
 // for information about this endpoint's return type.
 app.get('/alternates', async (req, res) => {
     const data = await getAlternates();
-    if (!data) return res.status(500).json({error: 'Alternates document malformed or nonexistant.'});
+    if (!data) return res.status(500).json({message: 'Alternates document malformed or nonexistant.'});
     return res.json(data);
 });
 
@@ -27,7 +27,18 @@ app.get('/alternates', async (req, res) => {
 // the returned schedule is an alternate.
 app.get('/schedule', async (req, res) => {
     const alternates = await getAlternates();
-    if (!alternates) return res.status(500).json({error: 'Alternates document malformed or nonexistant.'});
+    if (!alternates) return res.status(500).json({message: 'Alternates document malformed or nonexistant.'});
+
+    if (req.query.date) {
+        if (typeof req.query.date !== 'string')
+            return res.status(400).json({message: 'Query parameter "date" must be a string.'});
+
+        const date = DateTime.fromISO(req.query.date);
+        if (!date.isValid)
+            return res.status(400).json({message: `Error parsing date string: ${date.invalidExplanation}.`});
+
+        return res.json(getSchedule(date, alternates));
+    }
 
     const schedule = getSchedule(DateTime.now(), alternates);
     return res.json(schedule);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,3 +1,4 @@
+export {api} from './api';
 export {sgyauth} from './sgyauth';
 export * as sgyfetch from './sgyfetch';
 export * as weather from './weather';

--- a/functions/src/sgyauth.ts
+++ b/functions/src/sgyauth.ts
@@ -37,6 +37,7 @@ async function setAccessToken(uid: string, creds: {key: string, sec: string}, or
 }
 
 
+// sgyauth
 type AuthData = {oauth_token: string}
 export const sgyauth = functions.https.onCall(async (data: AuthData, context: functions.https.CallableContext) => {
     // If the context contains no firebase auth token, return early

--- a/functions/src/util/adminInit.ts
+++ b/functions/src/util/adminInit.ts
@@ -1,7 +1,6 @@
 import admin from 'firebase-admin';
 
-// const serviceAccount = require("../credentials/firebaseAdmin.json")
+
 admin.initializeApp();
-    // credential: admin.credential.cert(serviceAccount)
 
 export default admin;

--- a/functions/src/util/schedule.ts
+++ b/functions/src/util/schedule.ts
@@ -83,6 +83,55 @@ export function getNextPeriod(date: DateTime, alternates: {[key: string]: Period
     return {prev, next, startingIn, endingIn, nextSeconds};
 }
 
+// Logic from `/client/src/components/schedule/PeriodIndicator.tsx`.
+// https://github.com/GunnWATT/watt/blob/api/client/src/components/schedule/PeriodIndicator.tsx#L38-L44
+export function getNextPeriodMessage(date: DateTime, alternates: {[key: string]: PeriodObj[] | null}) {
+    const {next, startingIn, endingIn, nextSeconds} = getNextPeriod(date, alternates);
+    if (!next) return null;
+
+    const name = periodNameDefault(next.n);
+
+    if (startingIn >= 0) {
+        const num = startingIn || nextSeconds;
+        const unit = `${startingIn ? 'minute' : 'second'}${num !== 1 ? 's' : ''}`;
+
+        return `${name} starting in ${num} ${unit}.`
+    }
+
+    const endingNum = endingIn || nextSeconds;
+    const endingUnit = `${endingIn ? 'minute' : 'second'}${endingNum !== 1 ? 's' : ''}`;
+
+    // If the period started less than a minute ago, invert `nextSeconds` to get the seconds elapsed *since*
+    // the minute started.
+    const startedNum = startingIn !== -1 ? -startingIn : 60 - nextSeconds;
+    const startedUnit = `${startingIn !== -1 ? 'minute' : 'second'}${startedNum !== 1 ? 's' : ''}`;
+
+    return `${name} ending in ${endingNum} ${endingUnit}, started ${startedNum} ${startedUnit} ago.`
+}
+
+// Paste from `/client/src/components/schedule/Periods.tsx`.
+// https://github.com/GunnWATT/watt/blob/api/client/src/components/schedule/Periods.tsx#L149-L169
+export function periodNameDefault(name: string) {
+    if (!isNaN(parseInt(name))) return `Period ${name}`;
+
+    switch (name) {
+        case 'L':
+            return 'Lunch';
+        case 'S':
+            return 'SELF';
+        case 'P':
+            return 'PRIME';
+        case 'O':
+            return 'Office Hours';
+        case 'B':
+            return 'Brunch';
+        case 'A':
+            return 'No Class'; // for assignments that are not associated with a class
+        default:
+            return name;
+    }
+}
+
 const schedule: {[key: string]: PeriodObj[]} = {
     "M": [
         {

--- a/functions/src/util/schedule.ts
+++ b/functions/src/util/schedule.ts
@@ -1,0 +1,251 @@
+import {DateTime} from 'luxon';
+
+
+// See `/client/src/components/schedule/Periods.tsx`.
+type PeriodObj = {n: string, s: number, e: number, note?: string};
+
+export const SCHOOL_START = DateTime.fromISO('2021-08-11', {zone: 'America/Los_Angeles'}); // new Date(2021,7, 11);
+export const SCHOOL_END = DateTime.fromISO('2022-06-02', {zone: 'America/Los_Angeles'}); // new Date(2022, 5, 2);
+export const SCHOOL_END_EXCLUSIVE = DateTime.fromISO('2022-06-03', {zone: 'America/Los_Angeles'}); // new Date(2022, 5, 3);
+
+const numToWeekday = (num: number) => ['S', 'M', 'T', 'W', 'R', 'F', 'A'][num];
+
+
+// Paste from `/client/src/hooks/useSchedule.ts`.
+// See https://github.com/GunnWATT/watt/blob/main/client/src/hooks/useSchedule.ts#L45-L69 for further documentation.
+export function getSchedule(date: DateTime, alternates: {[key: string]: PeriodObj[] | null}) {
+    const localizedDate = date.setZone('America/Los_Angeles');
+    const altFormat = localizedDate.toFormat('MM-dd');
+
+    // If the current date falls on summer break, return early
+    if (localizedDate < SCHOOL_START || localizedDate > SCHOOL_END_EXCLUSIVE)
+        return {periods: null, alternate: false};
+
+    let periods: PeriodObj[] | null;
+    let alternate = false;
+
+    // Check for alternate schedules
+    if (altFormat in alternates) {
+        // If viewDate exists in alt schedules, load that schedule
+        periods = alternates[altFormat];
+        alternate = true;
+    } else {
+        // Otherwise, use default schedule
+        periods = schedule[numToWeekday(localizedDate.weekday % 7)];
+    }
+
+    return {periods, alternate};
+}
+
+const schedule: {[key: string]: PeriodObj[]} = {
+    "M": [
+        {
+            "n": "0",
+            "s": 475,
+            "e": 530
+        },
+        {
+            "n": "1",
+            "s": 540,
+            "e": 585
+        },
+        {
+            "n": "2",
+            "s": 595,
+            "e": 640
+        },
+        {
+            "n": "B",
+            "s": 640,
+            "e": 645
+        },
+        {
+            "n": "3",
+            "s": 655,
+            "e": 700
+        },
+        {
+            "n": "4",
+            "s": 710,
+            "e": 755
+        },
+        {
+            "n": "L",
+            "s": 755,
+            "e": 785
+        },
+        {
+            "n": "5",
+            "s": 795,
+            "e": 840
+        },
+        {
+            "n": "6",
+            "s": 850,
+            "e": 895
+        },
+        {
+            "n": "7",
+            "s": 905,
+            "e": 950
+        },
+        {
+            "n": "8",
+            "s": 960,
+            "e": 1005
+        }
+    ],
+    "T": [
+        {
+            "n": "0",
+            "s": 475,
+            "e": 530
+        },
+        {
+            "n": "1",
+            "s": 540,
+            "e": 635
+        },
+        {
+            "n": "B",
+            "s": 635,
+            "e": 640
+        },
+        {
+            "n": "2",
+            "s": 650,
+            "e": 740
+        },
+        {
+            "n": "L",
+            "s": 740,
+            "e": 770
+        },
+        {
+            "n": "3",
+            "s": 780,
+            "e": 870
+        },
+        {
+            "n": "4",
+            "s": 880,
+            "e": 970
+        },
+        {
+            "n": "8",
+            "s": 980,
+            "e": 1075
+        }
+    ],
+    "W": [
+        {
+            "n": "0",
+            "s": 475,
+            "e": 530
+        },
+        {
+            "n": "5",
+            "s": 540,
+            "e": 635
+        },
+        {
+            "n": "B",
+            "s": 635,
+            "e": 640
+        },
+        {
+            "n": "6",
+            "s": 650,
+            "e": 740
+        },
+        {
+            "n": "L",
+            "s": 740,
+            "e": 770
+        },
+        {
+            "n": "7",
+            "s": 780,
+            "e": 870
+        },
+        {
+            "n": "P",
+            "s": 880,
+            "e": 930
+        }
+    ],
+    "R": [
+        {
+            "n": "0",
+            "s": 475,
+            "e": 530
+        },
+        {
+            "n": "1",
+            "s": 540,
+            "e": 635
+        },
+        {
+            "n": "B",
+            "s": 635,
+            "e": 640
+        },
+        {
+            "n": "2",
+            "s": 650,
+            "e": 740
+        },
+        {
+            "n": "L",
+            "s": 740,
+            "e": 770
+        },
+        {
+            "n": "3",
+            "s": 780,
+            "e": 870
+        },
+        {
+            "n": "4",
+            "s": 880,
+            "e": 970
+        },
+        {
+            "n": "8",
+            "s": 980,
+            "e": 1075
+        }
+    ],
+    "F": [
+        {
+            "n": "5",
+            "s": 540,
+            "e": 635
+        },
+        {
+            "n": "B",
+            "s": 635,
+            "e": 640
+        },
+        {
+            "n": "6",
+            "s": 650,
+            "e": 740
+        },
+        {
+            "n": "L",
+            "s": 740,
+            "e": 770
+        },
+        {
+            "n": "S",
+            "s": 780,
+            "e": 830
+        },
+        {
+            "n": "7",
+            "s": 840,
+            "e": 930
+        }
+    ]
+}

--- a/functions/src/util/schedule.ts
+++ b/functions/src/util/schedule.ts
@@ -37,6 +37,52 @@ export function getSchedule(date: DateTime, alternates: {[key: string]: PeriodOb
     return {periods, alternate};
 }
 
+// Modified paste from `/client/src/hooks/useNextPeriod.ts`.
+// https://github.com/GunnWATT/watt/blob/main/client/src/hooks/useNextPeriod.ts#L5-L49
+export function getNextPeriod(date: DateTime, alternates: {[key: string]: PeriodObj[] | null}) {
+    const {periods} = getSchedule(date, alternates);
+
+    // Localize date to PST before attempting to parse next period
+    // TODO: do minutes and seconds *really* need to be returned by this hook?
+    const localizedDate = date.setZone('America/Los_Angeles');
+    const midnight = localizedDate.startOf('day');
+    const minutes = localizedDate.diff(midnight, 'minutes').minutes;
+    const seconds = localizedDate.diff(midnight, 'seconds').seconds;
+
+    // The seconds left in the current minute, for display when the time to the next start or end is less
+    // than a full minute.
+    const nextSeconds = 60 - (Math.floor(seconds % 60));
+
+    // Period variables
+    let prev = null, next = null;
+
+    if (!periods)
+        return {prev, next, startingIn: 0, endingIn: 0, nextSeconds};
+    if (minutes < periods[0].s - 20)
+        return {prev, next, startingIn: 0, endingIn: 0, nextSeconds};
+
+    // Loop through all periods, finding the index of the first period for which the current time is less
+    // than the end time.
+    let currPd;
+    for (currPd = 0; currPd < periods.length; currPd++) {
+        if (minutes < periods[currPd].e) break;
+    }
+
+    // If no period exists that has an end time after the current time, no next period exists.
+    if (currPd >= periods.length) {
+        prev = periods[periods.length - 1];
+    } else {
+        prev = periods[currPd - 1];
+        next = periods[currPd];
+    }
+
+    // The minutes to the start and end of the next period, or 0 if there is no next period.
+    const startingIn = next ? next.s - Math.ceil(minutes) : 0;
+    const endingIn = next ? next.e - Math.ceil(minutes) : 0;
+
+    return {prev, next, startingIn, endingIn, nextSeconds};
+}
+
 const schedule: {[key: string]: PeriodObj[]} = {
     "M": [
         {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,7 @@ imperfect match or if a club wasn't matched to an existing ID.
 
 ![image](https://user-images.githubusercontent.com/60120929/166117012-a3d04f1c-31a5-44a3-92d5-f870f78e0d80.png)
 
-Note that the spreadsheet this script fetches clubs from is hard coded and must be updated manually whenever a new 
+Note that the spreadsheet URL this script fetches clubs from is hard coded and must be updated manually whenever a new 
 spreadsheet is released.
 
 <!-- TODO: clean up staff scripts -->


### PR DESCRIPTION
This PR was requested by @saumyasinghal747 and readds `/functions/api` to handle requests to `/api`. Currently, the API has 2 endpoints:
- `GET /api/alternates` returns the `Alternates` object.
- `GET /api/schedule` returns the current days schedule, as `{periods: PeriodObj[] | null, alternate: boolean}`.

More endpoints can be added on demand. For API documentation, I was thinking of using both GitHub and hosting docs on WATT, probably under a lazy loaded subroute. Until `articles` is merged however, the former will have to do.