### PR TITLE
Reorganize Tailwind config colors

### DIFF
--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -7,23 +7,38 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        theme: '#a51618',
-        primary: 'rgba(0, 0, 0, 0.87)',
-        secondary: 'rgba(0, 0, 0, 0.54)',
-        tertiary: 'rgba(0, 0, 0, 0.1)',
-        content: 'white',
-        'content-secondary': '#e9ecef',
-        'sidebar': 'white',
-        'background': '#f7f8fd',
-
-        'theme-dark': '#ff594c',
-        'primary-dark': 'white',
-        'secondary-dark': 'rgba(255, 255, 255, 0.54)',
-        'tertiary-dark': 'rgba(255, 255, 255, 0.1)',
-        'content-dark': 'rgb(55, 55, 57)',
-        'content-secondary-dark': 'rgb(42, 42, 44)',
-        'sidebar-dark': 'rgb(25, 25, 27)',
-        'background-dark': 'rgb(35, 35, 37)'
+        theme: {
+          DEFAULT: '#a51618',
+          dark: '#ff594c'
+        },
+        primary: {
+          DEFAULT: 'rgba(0, 0, 0, 0.87)',
+          dark: 'white'
+        },
+        secondary: {
+          DEFAULT: 'rgba(0, 0, 0, 0.54)',
+          dark: 'rgba(255, 255, 255, 0.54)'
+        },
+        tertiary: {
+          DEFAULT: 'rgba(0, 0, 0, 0.1)',
+          dark: 'rgba(255, 255, 255, 0.1)'
+        },
+        content: {
+          DEFAULT: 'white',
+          dark: 'rgb(55, 55, 57)'
+        },
+        'content-secondary': {
+          DEFAULT: '#e9ecef',
+          dark: 'rgb(42, 42, 44)'
+        },
+        sidebar: {
+          DEFAULT: 'white',
+          dark: 'rgb(25, 25, 27)'
+        },
+        background: {
+          DEFAULT: '#f7f8fd',
+          dark: 'rgb(35, 35, 37)'
+        }
       }
     },
     container: {


### PR DESCRIPTION
Currently we define all colors manually and group them by theme, not color. If we wanted to, we could use tailwind's [color object syntax](https://tailwindcss.com/docs/customizing-colors#color-object-syntax) to group them by color. So far, that's all that this PR is for, but we also need to sort out CSS variables and eventually try to remove `base.scss`.

As for the switch to color objects, I like being able to have webstorm display the color preview boxes for each themes color palette on the left bar separately, but the object syntax may be better for keeping the same color (ie. `content-secondary`) together; the current setup treats `content-secondary` and `content-secondary-dark` as two different colors which may not be clear or semantic.