### PR TITLE
Fix mount `useEffect` in `List`

### DIFF
--- a/client/src/components/lists/List.tsx
+++ b/client/src/components/lists/List.tsx
@@ -24,7 +24,7 @@ export default function List<T>(props: ListProps<T>) {
     const {data, filter, map, sort, pinned: pinnedIds} = props;
     const [{pinned, unpinned}, setContent] = useState(parseContent());
 
-    // Parses content to JSX components, sorting, filtering, and splitting by pinned and unpinned.
+    // Maps content to JSX components, sorting, filtering, and splitting by pinned and unpinned.
     function parseContent() {
         // Parse data into mappable form
         const parsed = Array.isArray(data)

--- a/client/src/components/schedule/Events.tsx
+++ b/client/src/components/schedule/Events.tsx
@@ -38,7 +38,7 @@ export default function Events(props: EventsProps) {
 
 
     return (
-        <div className="flex flex-col list-none break-words px-5 py-4 xl:sticky xl:bg-content xl:rounded-lg xl:shadow-lg xl:top-6 xl:basis-80 xl:h-[calc(100vh_-_48px)]">
+        <div className="flex flex-col list-none break-words px-5 py-4 xl:sticky xl:bg-content xl:rounded-lg xl:shadow-lg xl:top-6 xl:basis-80 xl:min-w-0 xl:h-[calc(100vh_-_48px)]">
             <div>
                 <h2 className="text-3xl font-medium">Events</h2>
                 <hr/>

--- a/client/src/components/settings/PeriodCustomizationInput.tsx
+++ b/client/src/components/settings/PeriodCustomizationInput.tsx
@@ -27,12 +27,17 @@ export default function PeriodCustomizationInput(props: PeriodCustomizationInput
     const updatePeriodData = async (newValue: string, field: string) =>
         await updateUserData(`classes.${id}.${field}`, newValue, auth, firestore);
 
-    // const [color,setColor] = useState('#fff');
     const userData = useContext(UserDataContext);
     const [color, setColor] = useState(parsePeriodColor(id, userData));
     const changeColor = (color: ColorResult) => setColor(color.hex);
 
     const isUpperPeriod = ['0', '1', '2', '3'].includes(id);
+
+    // Update default colors on cross-device theme change.
+    // TODO: a bit unideal, but there doesn't seem to be another way to do this.
+    useEffect(() => {
+        setColor(parsePeriodColor(id, userData));
+    }, [userData.options.theme])
 
     return (
         <div className="periods-custom-row-burrito flex items-center gap-6">

--- a/client/src/components/settings/PeriodCustomizationInput.tsx
+++ b/client/src/components/settings/PeriodCustomizationInput.tsx
@@ -40,7 +40,7 @@ export default function PeriodCustomizationInput(props: PeriodCustomizationInput
     }, [userData.options.theme])
 
     return (
-        <div className="periods-custom-row-burrito flex items-center gap-6">
+        <div className="flex items-center gap-6">
             <Popover className="relative h-10">
                 <Popover.Button
                     className="w-10 h-10 rounded border-2 border-tertiary"


### PR DESCRIPTION
This allows lists to load in with the correct data already displayed, instead of initially rendering with `null` data and rerendering immediately on mount to populate. I want to stick this on a preview URL to test load times just in case, but if no significant performance loss is incurred this can be merged immediately.