### PR TITLE
Better classes list handling

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@headlessui/react": "^1.6.6",
+    "@headlessui/react": "^1.7.4",
     "firebase": "^9.14.0",
     "he": "^1.2.0",
     "luxon": "^3.1.0",

--- a/client/src/components/classes/ClassFilter.tsx
+++ b/client/src/components/classes/ClassFilter.tsx
@@ -68,7 +68,7 @@ export default function ClassFilter(props: ClassFilterProps) {
 
             <Tags>
                 {filter.classes.map((c, i) => c && (
-                    <AssignmentTag label={classes[i].name} color={classes[i].color} />
+                    <AssignmentTag label={classes[i + 1].name} color={classes[i + 1].color} />
                 ))}
                 {filter.labels.map(label => (
                     <AssignmentTag label={parseLabelName(label, userData)} color={parseLabelColor(label, userData)} />

--- a/client/src/components/classes/ClassFilter.tsx
+++ b/client/src/components/classes/ClassFilter.tsx
@@ -9,6 +9,7 @@ import Dot from '../layout/Dot';
 
 // Contexts
 import UserDataContext from '../../contexts/UserDataContext';
+import SgyDataContext from '../../contexts/SgyDataContext';
 
 // Utilities
 import {allLabels, parseLabelColor, parseLabelName} from '../../util/sgyLabels';
@@ -26,10 +27,11 @@ export type QueryObj = TagObj & { query: string }
 // returning the user's current filter as a `QueryObj` containing their search and selected tags.
 export type ClassFilterProps = {
     filter: QueryObj, setFilter: (query: QueryObj) => void,
-    classes: { name: string, color: string, period: string }[];
 };
 export default function ClassFilter(props: ClassFilterProps) {
-    const { filter, setFilter, classes } = props;
+    const { filter, setFilter } = props;
+
+    const {classes} = useContext(SgyDataContext);
     const userData = useContext(UserDataContext);
 
     const setClasses = (classes: boolean[]) => setFilter({...filter, classes});
@@ -53,7 +55,6 @@ export default function ClassFilter(props: ClassFilterProps) {
                                 selected={filter.classes}
                                 setSelected={setClasses}
                                 search={search}
-                                classes={classes}
                             />
                             <TagPickerLabels
                                 labels={filter.labels}
@@ -158,12 +159,12 @@ export function TagPickerLabels(props: TagPickerLabelsProps) {
 
 // The class picker section, which selects classes like "Analysis H Tantod" and "AP US History Johnson".
 type TagPickerClassesProps = {
-    classes: { name: string, color: string, period: string }[],
     selected: boolean[], setSelected: (filter: boolean[]) => void,
     search: string
 };
 export function TagPickerClasses(props: TagPickerClassesProps) {
-    const {classes, selected, setSelected, search} = props;
+    const {selected, setSelected, search} = props;
+    const {classes} = useContext(SgyDataContext);
 
     const setAllClasses = (value: boolean) => setSelected(selected.map(() => value));
     const selectAllClasses = () => setAllClasses(true);
@@ -182,7 +183,7 @@ export function TagPickerClasses(props: TagPickerClassesProps) {
             deselectAll={deselectAllClasses}
             noneSelected={selected.every((c) => !c)}
         >
-            {classes.map((c, index) => {
+            {classes.slice(1).map((c, index) => {
                 if (!c.name.toLowerCase().includes(search.toLowerCase())) return null;
                 return (
                     <TagPickerOption

--- a/client/src/components/classes/ClassesHeader.tsx
+++ b/client/src/components/classes/ClassesHeader.tsx
@@ -7,23 +7,18 @@ import AnimatedListbox from '../layout/AnimatedListbox';
 import Dot from '../layout/Dot';
 
 // Contexts
-import UserDataContext, {SgyPeriod} from '../../contexts/UserDataContext';
-import SgyDataContext from '../../contexts/SgyDataContext';
+import SgyDataContext, {AllSgyPeriod} from '../../contexts/SgyDataContext';
 
 // Utilities
-import {findClassesList} from './ClassesLayout';
 import {bgColor} from '../../util/progressBarColor';
 
 
-type ClassesHeaderProps = { selected: SgyPeriod | 'A', setSelected: (selected: SgyPeriod | 'A') => void };
+type ClassesHeaderProps = { setSelected: (selected: AllSgyPeriod) => void };
 export default function ClassesHeader(props: ClassesHeaderProps) {
-    const {selected, setSelected} = props;
+    const {setSelected} = props;
+    const {selected, classes} = useContext(SgyDataContext);
 
-    const userData = useContext(UserDataContext);
-    const {sgyData} = useContext(SgyDataContext);
-
-    const classes = findClassesList(sgyData, userData, true);
-    const {name: currName, color: currColor} = findClassesList(sgyData, userData).find(({period}) => period === selected)!;
+    const {name: currName, color: currColor} = classes.find(({period}) => period === selected)!;
 
     return (
         <Header>

--- a/client/src/components/classes/ClassesLayout.tsx
+++ b/client/src/components/classes/ClassesLayout.tsx
@@ -255,7 +255,7 @@ function ClassesErrorBurrito(props: {children?: ReactNode}) {
 
 // Returns a parsed class array given a populated userData object.
 // The first class will be an "All Courses" object with default color.
-function findClassesList(sgyData: SgyData, userData: UserData) {
+export function findClassesList(sgyData: SgyData, userData: UserData) {
     const classes: SgyClass[] = [];
 
     // Push "All Courses" object

--- a/client/src/components/classes/CreateAssignmentModal.tsx
+++ b/client/src/components/classes/CreateAssignmentModal.tsx
@@ -14,12 +14,11 @@ import { Tags, AssignmentTag } from './AssignmentTags';
 import {PopoverPlus, TagPicker, TagPickerLabels} from './ClassFilter';
 
 // Contexts
-import UserDataContext, { SgyPeriod } from '../../contexts/UserDataContext';
-import SgyDataContext from '../../contexts/SgyDataContext';
+import UserDataContext from '../../contexts/UserDataContext';
+import SgyDataContext, { SgyPeriod } from '../../contexts/SgyDataContext';
 import CurrentTimeContext from '../../contexts/CurrentTimeContext';
 
 // Utilities
-import { findClassesList } from './ClassesLayout';
 import { AssignmentBlurb, createAssignment, updateAssignment } from '../../util/sgyAssignments';
 import { parseLabelColor, parseLabelName } from '../../util/sgyLabels';
 import { parsePeriodColor, parsePeriodName } from '../schedule/Periods';
@@ -33,9 +32,7 @@ const PeriodPicker = (props: { period: 'A'|SgyPeriod, setPeriod: (c: 'A'|SgyPeri
     // however, because of how ClassFilter works this is tricky and I'll leave it for future cleanup
 
     const userData = useContext(UserDataContext);
-    const { sgyData } = useContext(SgyDataContext);
-
-    const classes = findClassesList(sgyData, userData);
+    const { classes } = useContext(SgyDataContext);
 
     return (
         <Popover className="relative">
@@ -43,7 +40,7 @@ const PeriodPicker = (props: { period: 'A'|SgyPeriod, setPeriod: (c: 'A'|SgyPeri
                 {parsePeriodName(period, userData)}
             </Popover.Button>
             <AnimatedPopover className="absolute top-[calc(100%_+_15px)] left-0 p-2.5 w-[300px] bg-content rounded-md z-10 flex flex-col gap-1.5">
-                {classes.map((c, index) => (
+                {classes.slice(1).map((c, index) => (
                     <div key={c.name} className="flex items-center gap-3 cursor-pointer" onClick={() => setPeriod(c.period)}>
                         <div
                             className="h-7 w-7 rounded-full flex-none"

--- a/client/src/components/classes/DashboardQuickInfo.tsx
+++ b/client/src/components/classes/DashboardQuickInfo.tsx
@@ -7,6 +7,7 @@ import AlternatesContext from '../../contexts/AlternatesContext';
 // Utilities
 import { cardinalize } from '../../util/sgyHelpers';
 import { ClassPeriodQuickInfo, pastClasses, nextSchoolDay, numSchoolDays } from '../../util/sgyPeriodFunctions';
+import {DATE_FULL_NO_YEAR} from '../../util/dateFormats';
 
 
 // Quick Info includes when's the next day that has a given period
@@ -53,7 +54,7 @@ export default function DashboardQuickInfo(props: { selected: string }) {
         <section>
             <h2 className="text-xl">The next class is {info.next.time.toRelative()}.</h2>
             <p className="text-secondary">
-                It will be on {info.next.time.toFormat('dddd, MMMM Do')}, and will be Week {info.next.week} Day {info.next.day},
+                It will be on {info.next.time.toLocaleString(DATE_FULL_NO_YEAR)}, and will be Week {info.next.week} Day {info.next.day},
                 the {cardinalize(info.past.days + 1)} class of the school year.
             </p>
         </section>

--- a/client/src/components/classes/Grades.tsx
+++ b/client/src/components/classes/Grades.tsx
@@ -6,20 +6,13 @@ import { FiChevronDown, FiChevronRight, FiChevronUp } from 'react-icons/all';
 import Dot from '../layout/Dot';
 
 // Context
-import UserDataContext from '../../contexts/UserDataContext';
 import SgyDataContext from '../../contexts/SgyDataContext';
-
-// Utilities
-import { findClassesList } from './ClassesLayout';
-import { classifyGrade } from '../../util/sgyHelpers';
 
 
 type GradesProps = { selected: string, allGrades: { [key: string]: number } };
 export default function Grades(props: GradesProps) {
     const { allGrades, selected } = props;
-
-    const userData = useContext(UserDataContext);
-    const { sgyData } = useContext(SgyDataContext);
+    const { classes } = useContext(SgyDataContext);
 
     if (selected !== 'A' && !allGrades[selected]) return null;
 
@@ -32,7 +25,7 @@ export default function Grades(props: GradesProps) {
                 </Disclosure.Button>
 
                 <Disclosure.Panel className="flex flex-col gap-2 px-4 py-3 rounded-lg bg-content-secondary/50 mb-4">
-                    {selected === 'A' ? findClassesList(sgyData, userData)
+                    {selected === 'A' ? classes
                         .filter(({ period }) => period !== 'A' && allGrades[period])
                         .map(({ name, color, period }) => (
                             <div key={period} className="flex gap-3 items-center">

--- a/client/src/components/classes/Material.tsx
+++ b/client/src/components/classes/Material.tsx
@@ -6,7 +6,7 @@ import {Tags, AssignmentTag} from './AssignmentTags';
 import Dot from '../layout/Dot';
 
 // Contexts
-import UserDataContext, {SgyData} from '../../contexts/UserDataContext';
+import UserDataContext from '../../contexts/UserDataContext';
 
 // Utilities
 import {parsePeriodColor} from '../schedule/Periods';
@@ -15,9 +15,9 @@ import {AssignmentBlurb} from '../../util/sgyAssignments';
 import {DATE_SHORT_YEAR_SHORTENED} from '../../util/dateFormats';
 
 
-type MaterialProps = { item: AssignmentBlurb, sgyData: SgyData };
+type MaterialProps = { item: AssignmentBlurb };
 export default function Material(props: MaterialProps) {
-    const { item, sgyData } = props;
+    const { item } = props;
 
     const userData = useContext(UserDataContext);
     const [modal, setModal] = useState(false);

--- a/client/src/contexts/SgyDataContext.ts
+++ b/client/src/contexts/SgyDataContext.ts
@@ -1,16 +1,36 @@
 import {createContext} from 'react';
-import { SgyPeriod, SgyData } from './UserDataContext';
+import {Assignment, Document, Event, Page, Section, SectionGrade} from '../util/sgyTypes';
+
+
+type SgyCourseData = {
+    info: Section;
+    documents: Document[];
+    assignments: Assignment[];
+    pages: Page[];
+    events: Event[];
+}
+export type SgyData = {
+    grades: SectionGrade[];
+    1?: SgyCourseData, 2?: SgyCourseData, 3?: SgyCourseData, 4?: SgyCourseData,
+    5?: SgyCourseData, 6?: SgyCourseData, 7?: SgyCourseData, S?: SgyCourseData,
+    0?: SgyCourseData, 8?: SgyCourseData
+};
+
+export type SgyPeriod = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '0' | 'S';
+export type AllSgyPeriod = SgyPeriod | 'A';
+export type SgyClass = {name: string, color: string, period: AllSgyPeriod};
 
 export type SgyContext = {
     sgyData: SgyData,
     fetching: boolean,
     lastFetched: number|null,
     lastAttemptedFetch: number | null,
-    selected: SgyPeriod|'A',
+    selected: SgyPeriod | 'A',
+    classes: SgyClass[],
     updateSgy: () => Promise<any>,
 };
 
-const DefaultSgyContext:SgyContext = {
+const defaultSgyContext: SgyContext = {
     sgyData: {
         grades: []
     },
@@ -18,10 +38,11 @@ const DefaultSgyContext:SgyContext = {
     lastFetched: null,
     lastAttemptedFetch: null,
     selected: 'A',
+    classes: [],
     updateSgy: async () => {},
 }
 
-const SgyDataContext = createContext<SgyContext>(DefaultSgyContext);
+const SgyDataContext = createContext<SgyContext>(defaultSgyContext);
 
 export const SgyDataProvider = SgyDataContext.Provider;
 export default SgyDataContext;

--- a/client/src/contexts/UserDataContext.ts
+++ b/client/src/contexts/UserDataContext.ts
@@ -1,5 +1,5 @@
 import {createContext} from 'react';
-import { Assignment, Document, Event, Page, Section, SectionGrade } from '../util/sgyTypes';
+import {AllSgyPeriod} from './SgyDataContext';
 
 
 // Represents a course on Schoology.
@@ -12,7 +12,7 @@ import { Assignment, Document, Event, Page, Section, SectionGrade } from '../uti
 export type SgyPeriodData = {n: string, c: string, l: string, o: string, s: string, r: string};
 
 export type CustomAssignment = {
-    id: string, name: string, description: string, labels: string[], timestamp: number | null, period: SgyPeriod|'A',
+    id: string, name: string, description: string, labels: string[], timestamp: number | null, period: AllSgyPeriod,
     completed: boolean, priority: number
 }
 export type SgyAssignmentModified = Partial<CustomAssignment> & {id: string}; // or Pick<CustomAssignment, 'id'>
@@ -41,21 +41,6 @@ export type UserData = {
         }
     }
 };
-
-type SgyCourseData = {
-    info: Section;
-    documents: Document[];
-    assignments: Assignment[];
-    pages: Page[];
-    events: Event[];
-}
-export type SgyData = {
-    grades: SectionGrade[];
-    1?: SgyCourseData, 2?: SgyCourseData, 3?: SgyCourseData, 4?: SgyCourseData,
-    5?: SgyCourseData, 6?: SgyCourseData, 7?: SgyCourseData, S?: SgyCourseData,
-    0?: SgyCourseData, 8?: SgyCourseData
-};
-export type SgyPeriod = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '0' | 'S';
 
 export const defaultUserData: UserData = {
     clubs: [],

--- a/client/src/hooks/useSgyGrades.ts
+++ b/client/src/hooks/useSgyGrades.ts
@@ -1,8 +1,30 @@
-import {SgyData, SgyPeriod, UserData} from "../contexts/UserDataContext";
-import {findClassesList} from "../components/classes/ClassesLayout";
+import {useContext} from 'react';
+import SgyDataContext, {SgyData, SgyPeriod} from '../contexts/SgyDataContext';
 
 
-// Find your grade objects
+// Returns all grades as numbers.
+export function useSgyGrades() {
+    const {sgyData, classes} = useContext(SgyDataContext);
+
+    const grades: { [key: string]: number } = {};
+
+    for (const c of classes) {
+        if (c.period === "A") continue;
+
+        const selectedCourseGrades = findGrades(sgyData, c.period); // find the grades
+        if (selectedCourseGrades) {
+            // Grading periods are listed in ascending order, with the latest grading period having the largest ID
+            // https://github.com/GunnWATT/watt/pull/91#discussion_r847901551
+            const latestPeriod = selectedCourseGrades.period.sort((a, b) => a.period_title.localeCompare(b.period_title)).pop();
+            const periodGrade = selectedCourseGrades.final_grade.find(g => g.period_id.toString() === latestPeriod?.period_id);
+            if (periodGrade) grades[c.period] = periodGrade.grade;
+        }
+    }
+
+    return grades;
+}
+
+// Finds the `SectionGrade` for the given `SgyPeriod`, or `null` if it does not exist.
 export function findGrades(sgyData: SgyData, selected: SgyPeriod) {
     const selectedCourse = sgyData[selected]!;
     // Attempt to match the id of the selected course to the id in the course grades
@@ -22,7 +44,7 @@ export function findGrades(sgyData: SgyData, selected: SgyPeriod) {
     for (const course in sgyData.grades) {
         for (const period of sgyData.grades[course].period) {
             for (const assignment of period.assignment) {
-                if (IDSet.has(assignment.assignment_id + '')) {
+                if (IDSet.has(assignment.assignment_id.toString())) {
                     // hallelujah
                     return sgyData.grades[course];
                 }
@@ -31,26 +53,4 @@ export function findGrades(sgyData: SgyData, selected: SgyPeriod) {
     }
 
     return null;
-}
-
-// Get all grades, but as numbers
-// wildly inefficient lol
-export function getAllGrades(sgyData: SgyData, userData: UserData) {
-    const classes = findClassesList(sgyData, userData);
-    const grades: { [key: string]: number } = {};
-
-    for (const c of classes) {
-        if (c.period === "A") continue;
-
-        const selectedCourseGrades = findGrades(sgyData, c.period); // find the grades
-        if (selectedCourseGrades) {
-            // Grading periods are listed in ascending order, with the latest grading period having the largest ID
-            // https://github.com/GunnWATT/watt/pull/91#discussion_r847901551
-            const latestPeriod = selectedCourseGrades.period.sort((a, b) => a.period_title.localeCompare(b.period_title)).pop();
-            const periodGrade = selectedCourseGrades.final_grade.find(g => g.period_id.toString() === latestPeriod?.period_id);
-            if (periodGrade) grades[c.period] = periodGrade.grade;
-        }
-    }
-
-    return grades;
 }

--- a/client/src/hooks/useSgyGrades.ts
+++ b/client/src/hooks/useSgyGrades.ts
@@ -10,6 +10,7 @@ export function useSgyGrades() {
 
     for (const c of classes) {
         if (c.period === "A") continue;
+        console.log(c)
 
         const selectedCourseGrades = findGrades(sgyData, c.period); // find the grades
         if (selectedCourseGrades) {
@@ -21,6 +22,7 @@ export function useSgyGrades() {
         }
     }
 
+    console.log(grades)
     return grades;
 }
 

--- a/client/src/pages/classes/Dashboard.tsx
+++ b/client/src/pages/classes/Dashboard.tsx
@@ -14,25 +14,19 @@ import SgyDataContext from '../../contexts/SgyDataContext';
 // Utilities
 import { AssignmentBlurb } from '../../util/sgyAssignments';
 import { getUpcomingInfo } from '../../util/sgyMaterials';
-import { getAllGrades } from '../../util/sgyGrades';
+import {useSgyGrades} from '../../hooks/useSgyGrades';
 
 
 export default function Dashboard() {
-    const {sgyData, selected, fetching, lastFetched, updateSgy} = useContext(SgyDataContext);
+    const {sgyData, selected} = useContext(SgyDataContext);
 
     const userData = useContext(UserDataContext);
     const time = useContext(CurrentTimeContext);
 
-    //const lastFetchedTime = lastFetched && moment(lastFetched);
-
     const [upcoming, setUpcoming] = useState<AssignmentBlurb[] | null>(null);
     const [overdue, setOverdue] = useState<AssignmentBlurb[] | null>(null);
-    const [allGrades, setAllGrades] = useState<{[key:string]: number} | null>(null);
 
-
-    useEffect(() => {
-        setAllGrades(getAllGrades(sgyData, userData));
-    }, [sgyData])
+    const allGrades = useSgyGrades();
 
     // TODO: precompute upcoming info for all classes
     useEffect(() => {

--- a/client/src/pages/classes/Dashboard.tsx
+++ b/client/src/pages/classes/Dashboard.tsx
@@ -1,4 +1,4 @@
-import {ReactNode, useContext, useEffect, useState} from 'react';
+import {ReactNode, useContext, useEffect, useMemo, useState} from 'react';
 
 // Components
 import DashboardBlurb from '../../components/classes/DashboardBlurb';
@@ -14,11 +14,11 @@ import SgyDataContext from '../../contexts/SgyDataContext';
 // Utilities
 import { AssignmentBlurb } from '../../util/sgyAssignments';
 import { getUpcomingInfo } from '../../util/sgyMaterials';
-import {useSgyGrades} from '../../hooks/useSgyGrades';
+import { getAllGrades } from '../../util/sgyGrades';
 
 
 export default function Dashboard() {
-    const {sgyData, selected} = useContext(SgyDataContext);
+    const {sgyData, classes, selected} = useContext(SgyDataContext);
 
     const userData = useContext(UserDataContext);
     const time = useContext(CurrentTimeContext);
@@ -26,7 +26,7 @@ export default function Dashboard() {
     const [upcoming, setUpcoming] = useState<AssignmentBlurb[] | null>(null);
     const [overdue, setOverdue] = useState<AssignmentBlurb[] | null>(null);
 
-    const allGrades = useSgyGrades();
+    const allGrades = useMemo(() => getAllGrades(sgyData, classes), [sgyData, classes]);
 
     // TODO: precompute upcoming info for all classes
     useEffect(() => {

--- a/client/src/pages/classes/Materials.tsx
+++ b/client/src/pages/classes/Materials.tsx
@@ -44,7 +44,7 @@ export default function Materials() {
                     filter.classes[classes.findIndex(({ period }) => assi.period === period)])
                 .filter((assi) => !filter.labels.length ||
                     assi.labels.some(label => filter.labels.includes(label)))
-                .map((item) => <Material key={item.id} item={item} sgyData={sgyData} />))
+                .map((item) => <Material key={item.id} item={item} />))
         });
     }, [materials, filter])
 

--- a/client/src/pages/classes/Materials.tsx
+++ b/client/src/pages/classes/Materials.tsx
@@ -23,7 +23,7 @@ export default function Materials() {
 
     // Filter
     const [filter, setFilter] = useState<QueryObj>({
-        query: '', labels: [], classes: Array(classes.length).fill(false)
+        query: '', labels: [], classes: Array(classes.length - 1).fill(false)
     });
 
     // Materials
@@ -41,7 +41,7 @@ export default function Materials() {
                     || similarity(filter.query, assi.name) >= 0.8
                     || similarity(filter.query, assi.description) >= 0.8)
                 .filter((assi) => filter.classes.every(c => !c) ||
-                    filter.classes[classes.findIndex(({ period }) => assi.period === period)])
+                    filter.classes[classes.findIndex(({ period }) => assi.period === period) - 1])
                 .filter((assi) => !filter.labels.length ||
                     assi.labels.some(label => filter.labels.includes(label)))
                 .map((item) => <Material key={item.id} item={item} />))

--- a/client/src/pages/classes/Materials.tsx
+++ b/client/src/pages/classes/Materials.tsx
@@ -6,22 +6,20 @@ import ClassFilter, {QueryObj} from '../../components/classes/ClassFilter';
 import NoResults from '../../components/lists/NoResults';
 
 // Contexts
-import UserDataContext, { SgyPeriod, SgyData } from '../../contexts/UserDataContext';
+import UserDataContext from '../../contexts/UserDataContext';
 import SgyDataContext from '../../contexts/SgyDataContext';
 
 // Utilities
-import { findClassesList } from '../../components/classes/ClassesLayout';
 import { similarity } from '../../util/sgyHelpers';
 import {AssignmentBlurb} from '../../util/sgyAssignments';
 import {getMaterials} from '../../util/sgyMaterials';
 
 
 export default function Materials() {
-    const { sgyData, selected } = useContext(SgyDataContext);
+    const { sgyData, selected, classes } = useContext(SgyDataContext);
 
     // Userdata handling
     const userData = useContext(UserDataContext);
-    const classes = findClassesList(sgyData, userData, false);
 
     // Filter
     const [filter, setFilter] = useState<QueryObj>({
@@ -52,7 +50,7 @@ export default function Materials() {
 
     return (
         <div className="flex flex-col gap-2">
-            <ClassFilter filter={filter} setFilter={setFilter} classes={classes} />
+            <ClassFilter filter={filter} setFilter={setFilter} />
             <section className="flex flex-col gap-1.5">
                 {content && content.length ? content : <NoResults />}
             </section>

--- a/client/src/pages/classes/Upcoming.tsx
+++ b/client/src/pages/classes/Upcoming.tsx
@@ -16,19 +16,17 @@ import UserDataContext from '../../contexts/UserDataContext';
 import SgyDataContext from '../../contexts/SgyDataContext';
 
 // Utilities
-import { findClassesList } from '../../components/classes/ClassesLayout';
 import {AssignmentBlurb} from '../../util/sgyAssignments';
 import { getUpcomingInfo } from '../../util/sgyMaterials';
 import { similarity } from '../../util/sgyHelpers';
 
 
 export default function Upcoming() {
-    const { sgyData, selected } = useContext(SgyDataContext);
-    const time = useContext(CurrentTimeContext);
-    const screenType = useScreenType();
-
     const userData = useContext(UserDataContext);
-    const classes = findClassesList(sgyData, userData);
+    const { sgyData, selected, classes } = useContext(SgyDataContext);
+    const time = useContext(CurrentTimeContext);
+
+    const screenType = useScreenType();
 
     const [upcoming, setUpcoming] = useState<AssignmentBlurb[] | null>(null);
     const [overdue, setOverdue] = useState<AssignmentBlurb[] | null>(null);
@@ -79,7 +77,7 @@ export default function Upcoming() {
         <div className="flex gap-6">
             {/* these props- */}
             <div className="flex-grow min-w-0">
-                <ClassFilter classes={classes} filter={filter} setFilter={setFilter} />
+                <ClassFilter filter={filter} setFilter={setFilter} />
 
                 <section className="flex items-center gap-2.5 mb-4">
                     <ContentButton onClick={() => setCreating(!creating)}>

--- a/client/src/pages/classes/Upcoming.tsx
+++ b/client/src/pages/classes/Upcoming.tsx
@@ -37,7 +37,7 @@ export default function Upcoming() {
 
     // Filter
     const [filter, setFilter] = useState<QueryObj>({
-        query: searchParams.get('search') ?? '', labels: [], classes: Array(classes.length).fill(false)
+        query: searchParams.get('search') ?? '', labels: [], classes: Array(classes.length - 1).fill(false)
     });
 
     const [includeCompleted, setIncludeCompleted] = useState(false);
@@ -53,7 +53,7 @@ export default function Upcoming() {
                 || similarity(filter.query, assi.name) >= 0.8
                 || similarity(filter.query, assi.description) >= 0.8)
             .filter((assi) => filter.classes.every(c => !c) ||
-                filter.classes[classes.findIndex(({period}) => assi.period === period)])
+                filter.classes[classes.findIndex(({period}) => assi.period === period) - 1])
             // .filter((assi) => assi.timestamp!.isAfter(start) && assi.timestamp!.isBefore(end))
             .filter((assi) => !assi.completed || includeCompleted)
             .filter((assi) => !filter.labels.length ||

--- a/client/src/util/sgyAssignments.ts
+++ b/client/src/util/sgyAssignments.ts
@@ -1,4 +1,5 @@
-import {CustomAssignment, SgyAssignmentModified, SgyPeriod, UserData} from "../contexts/UserDataContext";
+import {CustomAssignment, SgyAssignmentModified, UserData} from '../contexts/UserDataContext';
+import {AllSgyPeriod} from '../contexts/SgyDataContext';
 import {Auth} from "firebase/auth";
 import {Firestore} from "firebase/firestore";
 import {updateUserData} from "./firestore";
@@ -11,7 +12,7 @@ export type AssignmentBlurb = {
     link: string;
     timestamp: DateTime | null;
     description: string;
-    period: SgyPeriod|'A';
+    period: AllSgyPeriod;
     id: string;
     labels: string[];
     completed: boolean;

--- a/client/src/util/sgyGrades.ts
+++ b/client/src/util/sgyGrades.ts
@@ -1,16 +1,12 @@
-import {useContext} from 'react';
-import SgyDataContext, {SgyData, SgyPeriod} from '../contexts/SgyDataContext';
+import {SgyClass, SgyData, SgyPeriod} from '../contexts/SgyDataContext';
 
 
 // Returns all grades as numbers.
-export function useSgyGrades() {
-    const {sgyData, classes} = useContext(SgyDataContext);
-
+export function getAllGrades(sgyData: SgyData, classes: SgyClass[]) {
     const grades: { [key: string]: number } = {};
 
     for (const c of classes) {
         if (c.period === "A") continue;
-        console.log(c)
 
         const selectedCourseGrades = findGrades(sgyData, c.period); // find the grades
         if (selectedCourseGrades) {
@@ -22,7 +18,6 @@ export function useSgyGrades() {
         }
     }
 
-    console.log(grades)
     return grades;
 }
 

--- a/client/src/util/sgyMaterials.ts
+++ b/client/src/util/sgyMaterials.ts
@@ -9,7 +9,7 @@ import {AssignmentBlurb} from './sgyAssignments';
 
 // Utilities
 import {findClassesList} from '../components/classes/ClassesLayout';
-import {findGrades} from '../hooks/useSgyGrades';
+import {findGrades} from './sgyGrades';
 
 
 export function getMaterials(sgyData: SgyData, selected: AllSgyPeriod, userData: UserData): AssignmentBlurb[] {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "name": "@watt/client",
       "version": "0.1.0",
       "dependencies": {
-        "@headlessui/react": "^1.6.6",
+        "@headlessui/react": "^1.7.4",
         "firebase": "^9.14.0",
         "he": "^1.2.0",
         "luxon": "^3.1.0",
@@ -2705,9 +2705,12 @@
       }
     },
     "node_modules/@headlessui/react": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.6.6.tgz",
-      "integrity": "sha512-MFJtmj9Xh/hhBMhLccGbBoSk+sk61BlP6sJe4uQcVMtXZhCgGqd2GyIQzzmsdPdTEWGSF434CBi8mnhR6um46Q==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.4.tgz",
+      "integrity": "sha512-D8n5yGCF3WIkPsjEYeM8knn9jQ70bigGGb5aUvN6y4BGxcT3OcOQOKcM3zRGllRCZCFxCZyQvYJF6ZE7bQUOyQ==",
+      "dependencies": {
+        "client-only": "^0.0.1"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -3853,6 +3856,11 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -11076,10 +11084,12 @@
       }
     },
     "@headlessui/react": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.6.6.tgz",
-      "integrity": "sha512-MFJtmj9Xh/hhBMhLccGbBoSk+sk61BlP6sJe4uQcVMtXZhCgGqd2GyIQzzmsdPdTEWGSF434CBi8mnhR6um46Q==",
-      "requires": {}
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.4.tgz",
+      "integrity": "sha512-D8n5yGCF3WIkPsjEYeM8knn9jQ70bigGGb5aUvN6y4BGxcT3OcOQOKcM3zRGllRCZCFxCZyQvYJF6ZE7bQUOyQ==",
+      "requires": {
+        "client-only": "^0.0.1"
+      }
     },
     "@icons/material": {
       "version": "0.2.4",
@@ -11620,7 +11630,7 @@
     "@watt/client": {
       "version": "file:client",
       "requires": {
-        "@headlessui/react": "^1.6.6",
+        "@headlessui/react": "1.7.4",
         "@types/he": "^1.1.2",
         "@types/luxon": "^3.1.0",
         "@types/react": "^18.0.15",
@@ -11631,7 +11641,7 @@
         "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^2.2.0",
         "autoprefixer": "^10.4.7",
-        "firebase": "9.14.0",
+        "firebase": "^9.14.0",
         "he": "^1.2.0",
         "luxon": "^3.1.0",
         "postcss": "^8.4.14",
@@ -12062,6 +12072,11 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
+    },
+    "client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "cliui": {
       "version": "7.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11630,7 +11630,7 @@
     "@watt/client": {
       "version": "file:client",
       "requires": {
-        "@headlessui/react": "1.7.4",
+        "@headlessui/react": "^1.7.4",
         "@types/he": "^1.1.2",
         "@types/luxon": "^3.1.0",
         "@types/react": "^18.0.15",


### PR DESCRIPTION
This PR takes the `findClassesList()` calls out of individual components and pages and isolates it at the `ClassesLayout` root, to be passed down via context. It also removes the `includeAll` option to always include the "All Classes" object, changing logic accordingly (this needs to be tested on a preview URL).

This is better because this requires less prop passing and reduces inconsistencies between where `findClassesList()` was being used (the class filter in `Upcoming` erroneously had the "All Classes" object in the picker, while the filter in `Materials` did not). Also, it prevents multiple calls of `findClassesList()` which is a slight performance improvement.

This PR also improves typing slightly with a new type for `SgyClass` (what `findClassesList()` returns) and `AllSgyPeriod` (equivalent to `SgyPeriod | 'A'`, which was used frequently).