### PR TITLE
Center navigation buttons on mobile

### DIFF
--- a/client/src/components/layout/BottomNav.tsx
+++ b/client/src/components/layout/BottomNav.tsx
@@ -26,7 +26,7 @@ export default function BottomNav() {
                 {/* Dropup */}
                 <Popover className="relative flex">
                     {({open}) => (<>
-                        <Popover.Button className="p-2 rounded focus:outline-none focus-visible:ring-[3px] focus-visible:ring-[0xFF7DADD9]">
+                        <Popover.Button className="p-2 px-3 rounded focus:outline-none focus-visible:ring-[3px] focus-visible:ring-[0xFF7DADD9]">
                             {open ? <FiChevronDown className="w-6 h-6" /> : <FiChevronUp className="w-6 h-6" />}
                         </Popover.Button>
 


### PR DESCRIPTION
Noticed the mobile bottom navigation buttons were ever so slightly off centered

Before:
![before](https://github.com/GunnWATT/watt/assets/80350771/fba2f3cf-52c0-4bd4-9c70-27f3da86c490)
After:
![after](https://github.com/GunnWATT/watt/assets/80350771/daf553ba-4343-4a9b-abe6-da828906025f)
