### PR TITLE
Eternal "Fetching courses..." modal fix

### DIFF
--- a/client/src/components/firebase/SgyInitResults.tsx
+++ b/client/src/components/firebase/SgyInitResults.tsx
@@ -9,6 +9,7 @@ import Loading from '../layout/Loading';
 
 // Auth
 import { useAuth, useFirestore, useFunctions, useUser } from 'reactfire';
+import { onAuthStateChanged } from 'firebase/auth';
 import { httpsCallable } from 'firebase/functions';
 import { updateUserData } from '../../util/firestore';
 
@@ -31,14 +32,16 @@ export default function SgyInitResults() {
 
     // Set the results to the value returned by initialization to be displayed
     useEffect(() => {
-        if (auth.currentUser && sgyModal) {
-            // console.log('hey!');
-            const init = httpsCallable(functions, "sgyfetch-init");
-            init().then(r => {
-                // console.log(r);
-                setResults(r);
-            });
-        }
+		onAuthStateChanged(auth, (user) => {
+			if (user && sgyModal) {
+				// console.log('hey!');
+				const init = httpsCallable(functions, "sgyfetch-init");
+				init().then(r => {
+					// console.log(r);
+					setResults(r);
+				});
+			}
+		})
         // return (() => {console.log('I am unmounted!!!!!')});
     }, [])
 

--- a/client/src/components/firebase/SgyInitResults.tsx
+++ b/client/src/components/firebase/SgyInitResults.tsx
@@ -9,7 +9,6 @@ import Loading from '../layout/Loading';
 
 // Auth
 import { useAuth, useFirestore, useFunctions, useUser } from 'reactfire';
-import { onAuthStateChanged } from 'firebase/auth';
 import { httpsCallable } from 'firebase/functions';
 import { updateUserData } from '../../util/firestore';
 
@@ -32,18 +31,17 @@ export default function SgyInitResults() {
 
     // Set the results to the value returned by initialization to be displayed
     useEffect(() => {
-		onAuthStateChanged(auth, (user) => {
-			if (user && sgyModal) {
-				// console.log('hey!');
-				const init = httpsCallable(functions, "sgyfetch-init");
-				init().then(r => {
-					// console.log(r);
-					setResults(r);
-				});
-			}
-		})
+        if (!auth.currentUser) return;
+        if (auth.currentUser && sgyModal) {
+            // console.log('hey!');
+            const init = httpsCallable(functions, "sgyfetch-init");
+            init().then(r => {
+                // console.log(r);
+                setResults(r);
+            });
+        }
         // return (() => {console.log('I am unmounted!!!!!')});
-    }, [])
+    }, [auth.currentUser])
 
     const closeDialog = () => {
         setSgyModal(false);


### PR DESCRIPTION
All my friends linking their Schoology to WATT were greeted with this modal for eternity, after the Schoology callback:
![image](https://github.com/GunnWATT/watt/assets/80350771/e5a23608-0ec3-467a-94ae-e7373331f367)

Seems like `auth.currentUser` is never re-checked from its initial `null` state, not allowing the `results` state to ever change.
![image](https://github.com/GunnWATT/watt/assets/80350771/8a7406d7-0248-49dc-892d-ccbddeb256f1)

I believe the issue appeared sometime before this year as older Schoology integrations such as mine aren't affected, although, resetting the Schoology integration through the dedicated button seems to yield the same eternal modal.
![image](https://github.com/GunnWATT/watt/assets/80350771/5f130dba-4df9-4499-847c-5abf10ab1516)
